### PR TITLE
Handle `ExtensionInitialised` event

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,6 @@ module.exports = {
     'no-lone-blocks': 'off',
     'no-useless-return': 'off',
     '@typescript-eslint/member-delimiter-style': 'off',
+    '@typescript-eslint/indent': 'off',
   },
 };

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -52,11 +52,20 @@ export const mutations = {
       }
     }
   `,
-  updateColonyExtension: /* GraphQL */ `
-    mutation UpdateColonyExtension(
+  updateColonyExtensionByColonyAndHash: /* GraphQL */ `
+    mutation UpdateColonyExtensionByColonyAndHash(
       $input: UpdateExtensionByColonyAndHashInput!
     ) {
       updateExtensionByColonyAndHash(input: $input) {
+        id
+      }
+    }
+  `,
+  updateColonyExtensionByAddress: /* GraphQL */ `
+    mutation UpdateColonyExtensionByAddress(
+      $input: UpdateColonyExtensionInput!
+    ) {
+      updateColonyExtension(input: $input) {
         id
       }
     }

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -1,5 +1,6 @@
 import {
   addColonyEventListener,
+  addExtensionEventListener,
   addNetworkEventListener,
   addTokenEventListener,
 } from './utils';
@@ -17,6 +18,15 @@ export const colonySpecificEventsListener = async (
     colonyAddress,
   );
   await addTokenEventListener(ContractEventsSignatures.Transfer, colonyAddress);
+};
+
+export const extensionSpecificEventsListener = async (
+  extensionAddress: string,
+): Promise<void> => {
+  await addExtensionEventListener(
+    ContractEventsSignatures.ExtensionInitialised,
+    extensionAddress,
+  );
 };
 
 const eventListener = async (): Promise<void> => {

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -4,6 +4,12 @@ import { extensionSpecificEventsListener } from './eventListener';
 import networkClient from './networkClient';
 import { verbose } from './utils';
 
+/**
+ * Defines extensions for which we want to track ExtensionInitialised events
+ * Note: If an extension config in CDapp doesn't specify initialization params,
+ * it is considered enabled straight after installation and we don't need
+ * to track ExtensionInitialised events for it (e.g. OneTxPayment)
+ */
 const supportedExtensionIds = [getExtensionHash(Extension.VotingReputation)];
 
 export default async (): Promise<void> => {

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -1,0 +1,62 @@
+import { Extension, getExtensionHash, getLogs } from '@colony/colony-js';
+import { extensionSpecificEventsListener } from './eventListener';
+
+import networkClient from './networkClient';
+import { verbose } from './utils';
+
+const supportedExtensionIds = [getExtensionHash(Extension.VotingReputation)];
+
+export default async (): Promise<void> => {
+  verbose('Fetching already installed extensions');
+
+  supportedExtensionIds.forEach(async (extensionId) => {
+    const extensionInstalledLogs = await getLogs(
+      networkClient,
+      networkClient.filters.ExtensionInstalled(extensionId),
+    );
+    const extensionUninstalledLogs = await getLogs(
+      networkClient,
+      networkClient.filters.ExtensionUninstalled(extensionId),
+    );
+
+    /**
+     * Looping through the logs to create a mapping between colonies
+     * and the number of extension installations we encounter, minus uninstallations
+     */
+    const installedInColonyCount: { [address: string]: number } = {};
+    extensionInstalledLogs.forEach(async (log) => {
+      const parsedLog = networkClient.interface.parseLog(log);
+      const { colony } = parsedLog.args;
+
+      if (colony in installedInColonyCount) {
+        installedInColonyCount[colony]++;
+      } else {
+        installedInColonyCount[colony] = 1;
+      }
+    });
+    extensionUninstalledLogs.forEach((log) => {
+      const parsedLog = networkClient.interface.parseLog(log);
+      const { colony } = parsedLog.args;
+
+      if (colony in installedInColonyCount) {
+        installedInColonyCount[colony]--;
+      }
+    });
+
+    /**
+     * Only the colonies with installation count > 0 have this extension currently installed
+     */
+    for (const [colony, installationsCount] of Object.entries(
+      installedInColonyCount,
+    )) {
+      if (installationsCount > 0) {
+        const extensionAddress = await networkClient.getExtensionInstallation(
+          extensionId,
+          colony,
+        );
+
+        await extensionSpecificEventsListener(extensionAddress);
+      }
+    }
+  });
+};

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -24,7 +24,7 @@ export default async (): Promise<void> => {
      * and the number of extension installations we encounter, minus uninstallations
      */
     const installedInColonyCount: { [address: string]: number } = {};
-    extensionInstalledLogs.forEach(async (log) => {
+    extensionInstalledLogs.forEach((log) => {
       const parsedLog = networkClient.interface.parseLog(log);
       const { colony } = parsedLog.args;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export enum ContractEventsSignatures {
   ExtensionUninstalled = 'ExtensionUninstalled(bytes32,address)',
   ExtensionDeprecated = 'ExtensionDeprecated(bytes32,address,bool)',
   ExtensionUpgraded = 'ExtensionUpgraded(indexed bytes32,indexed address,uint256)',
+  ExtensionInitialised = 'ExtensionInitialised()',
 }
 
 /*


### PR DESCRIPTION
This required some changes to how events are listened for in the block-ingestor and my solution feels quite hacky so @rdig feel free to suggest alternatives.

When `ExtensionInstalled` event is picked up, block-ingestor will start listening for `ExtensionInitialised` event specific to that extension instance. It will then update the extension in the database to reflect its initialised status.

For extensions that had been installed before the block-ingestor started, there's a new `trackExtensions` function for each supported extension (currently just the VotingReputation) will iterate over and sum the number of installed and uninstalled events. If the number of installations is higher than uninstallation, it will add an `ExtensionInitialised` event listener for that particular extension in a colony.

## Testing
1. Checkout CDapp to extensions branch - `git checkout port/42-extensions`.
2. Still in CDapp, apply the following patch to disable ingestor image:
```diff
diff --git a/docker/colony-cdapp-dev-env-orchestration.yaml b/docker/colony-cdapp-dev-env-orchestration.yaml
index 6e2a133..f319cc6 100644
--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -28,19 +28,19 @@ services:
     links:
     - "network-contracts:network-contracts.docker"
 
-  block-ingestor:
-    container_name: 'ingestor'
-    image: colony-cdapp-dev-env/block-ingestor:latest
-    volumes:
-      - '../amplify/mock-data:/colonyCDapp/amplify/mock-data'
-    ports:
-      - '10001:10001'
-    depends_on:
-      network-contracts:
-        condition: service_healthy
-    links:
-      - "network-contracts:network-contracts.docker"
-      - "amplify:amplify.docker"
+  # block-ingestor:
+  #   container_name: 'ingestor'
+  #   image: colony-cdapp-dev-env/block-ingestor:latest
+  #   volumes:
+  #     - '../amplify/mock-data:/colonyCDapp/amplify/mock-data'
+  #   ports:
+  #     - '10001:10001'
+  #   depends_on:
+  #     network-contracts:
+  #       condition: service_healthy
+  #   links:
+  #     - "network-contracts:network-contracts.docker"
+  #     - "amplify:amplify.docker"
 
   amplify:
     container_name: 'amplify'

```
3. Run other images with `npm run dev` in CDapp directory.
4. Start the block-ingestor with `npm run dev`.
5. Run the `temp-create-data` script. Install and enable VotingReputation extension. 
6. After refreshing the page, it should show up as Enabled:
<img width="369" alt="image" src="https://user-images.githubusercontent.com/112586815/209411918-38d05fd1-b28f-4c2f-a9ea-2ec4ec29ccbf.png">

7. Uninstall the extension. Restart the block-ingestor to see `trackExtensions` in action. You should see a log informing you that a listener has been added: `Added listener for Event: ExtensionInitialised()`. Enabling should still work as described above.

TODO:
 - [x] Track previously installed extensions