### PR TITLE
Track colony versions in the database

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -70,6 +70,13 @@ export const mutations = {
       }
     }
   `,
+  updateColony: /* GraphQL */ `
+    mutation UpdateColony($input: UpdateColonyInput!) {
+      updateColony(input: $input) {
+        id
+      }
+    }
+  `,
 };
 
 /*

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const COLONY_CURRENT_VERSION_KEY = 'colony';

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -17,6 +17,10 @@ export const colonySpecificEventsListener = async (
     ContractEventsSignatures.ColonyFundsClaimed,
     colonyAddress,
   );
+  await addColonyEventListener(
+    ContractEventsSignatures.ColonyUpgraded,
+    colonyAddress,
+  );
   await addTokenEventListener(ContractEventsSignatures.Transfer, colonyAddress);
 };
 

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -37,6 +37,8 @@ const eventListener = async (): Promise<void> => {
   await addNetworkEventListener(ContractEventsSignatures.ExtensionUninstalled);
   await addNetworkEventListener(ContractEventsSignatures.ExtensionDeprecated);
   await addNetworkEventListener(ContractEventsSignatures.ExtensionUpgraded);
+
+  await addNetworkEventListener(ContractEventsSignatures.ColonyVersionAdded);
 };
 
 export default eventListener;

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -11,6 +11,7 @@ import {
 import { getChainId } from './provider';
 import { query, mutate } from './amplifyClient';
 import { ContractEventsSignatures, ContractEvent } from './types';
+import { COLONY_CURRENT_VERSION_KEY } from './constants';
 
 dotenv.config();
 
@@ -224,7 +225,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
       await mutate('setCurrentVersion', {
         input: {
-          key: 'colony',
+          key: COLONY_CURRENT_VERSION_KEY,
           version: convertedVersion,
         },
       });

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -216,6 +216,19 @@ export default async (event: ContractEvent): Promise<void> => {
       return;
     }
 
+    case ContractEventsSignatures.ColonyVersionAdded: {
+      const { version } = event.args;
+
+      await mutate('setCurrentVersion', {
+        input: {
+          item: 'COLONY',
+          version: BigNumber.from(version).toNumber(),
+        },
+      });
+
+      return;
+    }
+
     case ContractEventsSignatures.ExtensionAddedToNetwork: {
       const { extensionId, version } = event.args;
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -229,6 +229,19 @@ export default async (event: ContractEvent): Promise<void> => {
       return;
     }
 
+    case ContractEventsSignatures.ColonyUpgraded: {
+      const { newVersion } = event.args;
+
+      await mutate('updateColony', {
+        input: {
+          id: event.contractAddress,
+          version: BigNumber.from(newVersion).toNumber(),
+        },
+      });
+
+      return;
+    }
+
     case ContractEventsSignatures.ExtensionAddedToNetwork: {
       const { extensionId, version } = event.args;
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -218,13 +218,14 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ColonyVersionAdded: {
       const { version } = event.args;
+      const convertedVersion = BigNumber.from(version).toNumber();
 
-      verbose('New colony version:', version, 'added to network');
+      verbose('New colony version:', convertedVersion, 'added to network');
 
       await mutate('setCurrentVersion', {
         input: {
           key: 'colony',
-          version: BigNumber.from(version).toNumber(),
+          version: convertedVersion,
         },
       });
 
@@ -234,13 +235,18 @@ export default async (event: ContractEvent): Promise<void> => {
     case ContractEventsSignatures.ColonyUpgraded: {
       const { contractAddress } = event;
       const { newVersion } = event.args;
+      const convertedVersion = BigNumber.from(newVersion).toNumber();
 
-      verbose('Colony:', contractAddress, `upgraded to version ${newVersion}`);
+      verbose(
+        'Colony:',
+        contractAddress,
+        `upgraded to version ${convertedVersion}`,
+      );
 
       await mutate('updateColony', {
         input: {
           id: event.contractAddress,
-          version: BigNumber.from(newVersion).toNumber(),
+          version: convertedVersion,
         },
       });
 
@@ -249,18 +255,19 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExtensionAddedToNetwork: {
       const { extensionId, version } = event.args;
+      const convertedVersion = BigNumber.from(version).toNumber();
 
       verbose(
         'Extension:',
         extensionId,
-        `(version ${version})`,
+        `(version ${convertedVersion})`,
         'added to network',
       );
 
       await mutate('setCurrentVersion', {
         input: {
           key: extensionId,
-          version: BigNumber.from(version).toNumber(),
+          version: convertedVersion,
         },
       });
 
@@ -270,6 +277,7 @@ export default async (event: ContractEvent): Promise<void> => {
     case ContractEventsSignatures.ExtensionInstalled: {
       const { transactionHash, timestamp } = event;
       const { extensionId, colony, version } = event.args;
+      const convertedVersion = BigNumber.from(version).toNumber();
 
       const extensionAddress = await networkClient.getExtensionInstallation(
         extensionId,
@@ -284,7 +292,7 @@ export default async (event: ContractEvent): Promise<void> => {
       verbose(
         'Extension:',
         extensionId,
-        `(version ${version})`,
+        `(version ${convertedVersion})`,
         'installed in Colony:',
         colony,
       );
@@ -294,7 +302,7 @@ export default async (event: ContractEvent): Promise<void> => {
           id: extensionAddress,
           colonyId: colony,
           hash: extensionId,
-          version: BigNumber.from(version).toNumber(),
+          version: convertedVersion,
           installedBy,
           installedAt: timestamp,
           isDeprecated: false,
@@ -348,12 +356,13 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExtensionUpgraded: {
       const { extensionId, colony, version } = event.args;
+      const convertedVersion = BigNumber.from(version).toNumber();
 
       verbose(
         'Extension:',
         extensionId,
         'upgraded to version',
-        version,
+        convertedVersion,
         'in Colony:',
         colony,
       );
@@ -362,7 +371,7 @@ export default async (event: ContractEvent): Promise<void> => {
         input: {
           colonyId: colony,
           hash: extensionId,
-          version: BigNumber.from(version).toNumber(),
+          version: convertedVersion,
         },
       });
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -221,7 +221,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
       await mutate('setCurrentVersion', {
         input: {
-          item: 'colony',
+          key: 'colony',
           version: BigNumber.from(version).toNumber(),
         },
       });
@@ -247,7 +247,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
       await mutate('setCurrentVersion', {
         input: {
-          item: extensionId,
+          key: extensionId,
           version: BigNumber.from(version).toNumber(),
         },
       });

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -221,7 +221,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
       await mutate('setCurrentVersion', {
         input: {
-          item: 'COLONY',
+          item: 'colony',
           version: BigNumber.from(version).toNumber(),
         },
       });

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -219,6 +219,8 @@ export default async (event: ContractEvent): Promise<void> => {
     case ContractEventsSignatures.ColonyVersionAdded: {
       const { version } = event.args;
 
+      verbose('New colony version:', version, 'added to network');
+
       await mutate('setCurrentVersion', {
         input: {
           key: 'colony',
@@ -230,7 +232,10 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ColonyUpgraded: {
+      const { contractAddress } = event;
       const { newVersion } = event.args;
+
+      verbose('Colony:', contractAddress, `upgraded to version ${newVersion}`);
 
       await mutate('updateColony', {
         input: {
@@ -244,6 +249,13 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExtensionAddedToNetwork: {
       const { extensionId, version } = event.args;
+
+      verbose(
+        'Extension:',
+        extensionId,
+        `(version ${version})`,
+        'added to network',
+      );
 
       await mutate('setCurrentVersion', {
         input: {

--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -1,10 +1,18 @@
 import dotenv from 'dotenv';
 import { getLogs } from '@colony/colony-js';
+import { BigNumber } from 'ethers';
 
 import networkClient from './networkClient';
-import { output, writeJsonStats, verbose, addNetworkEventListener, setToJS } from './utils';
+import {
+  output,
+  writeJsonStats,
+  verbose,
+  addNetworkEventListener,
+  setToJS,
+} from './utils';
 import { colonySpecificEventsListener } from './eventListener';
 import { ContractEventsSignatures } from './types';
+import { mutate } from './amplifyClient';
 
 dotenv.config();
 
@@ -23,8 +31,10 @@ export default async (): Promise<void> => {
     networkClient.filters.ColonyAdded(),
   );
 
-  colonyAddedLogs.map(log => {
-    const { args: { colonyAddress, token: tokenAddress } } = networkClient.interface.parseLog(log) || {};
+  colonyAddedLogs.map((log) => {
+    const {
+      args: { colonyAddress, token: tokenAddress },
+    } = networkClient.interface.parseLog(log) || {};
     /*
      * Add found colonies to a Set
      * - We're using a Set to ensure uniquess
@@ -43,7 +53,8 @@ export default async (): Promise<void> => {
    */
   await Promise.all(
     setToJS(coloniesSet).map(
-      async ({ colonyAddress }) => await colonySpecificEventsListener(colonyAddress),
+      async ({ colonyAddress }) =>
+        await colonySpecificEventsListener(colonyAddress),
     ),
   );
 
@@ -51,4 +62,21 @@ export default async (): Promise<void> => {
    * Set a Network level listener to track new colonies that will get created on chain
    */
   await addNetworkEventListener(ContractEventsSignatures.ColonyAdded);
+
+  await writeCurrentNetworkColonyVersion();
+};
+
+/*
+ * Function writing the highest colony version currently available in the network to the database
+ * Subsequent changes to available version are handled in eventProcessor
+ */
+const writeCurrentNetworkColonyVersion = async (): Promise<void> => {
+  const version = await networkClient.getCurrentColonyVersion();
+
+  await mutate('setCurrentVersion', {
+    input: {
+      item: 'colony',
+      version: BigNumber.from(version).toNumber(),
+    },
+  });
 };

--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -13,6 +13,7 @@ import {
 import { colonySpecificEventsListener } from './eventListener';
 import { ContractEventsSignatures } from './types';
 import { mutate } from './amplifyClient';
+import { COLONY_CURRENT_VERSION_KEY } from './constants';
 
 dotenv.config();
 
@@ -75,7 +76,7 @@ const writeCurrentNetworkColonyVersion = async (): Promise<void> => {
 
   await mutate('setCurrentVersion', {
     input: {
-      key: 'colony',
+      key: COLONY_CURRENT_VERSION_KEY,
       version: BigNumber.from(version).toNumber(),
     },
   });

--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -75,7 +75,7 @@ const writeCurrentNetworkColonyVersion = async (): Promise<void> => {
 
   await mutate('setCurrentVersion', {
     input: {
-      item: 'colony',
+      key: 'colony',
       version: BigNumber.from(version).toNumber(),
     },
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export enum ContractEventsSignatures {
   ColonyAdded = 'ColonyAdded(uint256,address,address)',
   Transfer = 'Transfer(address,address,uint256)',
   ColonyFundsClaimed = 'ColonyFundsClaimed(address,address,uint256,uint256)',
+  ColonyVersionAdded = 'ColonyVersionAdded(uint256,address)',
   ExtensionAddedToNetwork = 'ExtensionAddedToNetwork(bytes32,uint256)',
   ExtensionInstalled = 'ExtensionInstalled(bytes32,address,uint256)',
   ExtensionUninstalled = 'ExtensionUninstalled(bytes32,address)',

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export enum ContractEventsSignatures {
   Transfer = 'Transfer(address,address,uint256)',
   ColonyFundsClaimed = 'ColonyFundsClaimed(address,address,uint256,uint256)',
   ColonyVersionAdded = 'ColonyVersionAdded(uint256,address)',
+  ColonyUpgraded = 'ColonyUpgraded(address,uint256,uint256)',
   ExtensionAddedToNetwork = 'ExtensionAddedToNetwork(bytes32,uint256)',
   ExtensionInstalled = 'ExtensionInstalled(bytes32,address,uint256)',
   ExtensionUninstalled = 'ExtensionUninstalled(bytes32,address)',


### PR DESCRIPTION
## Description

This PR adds two concepts of tracking colony version:
 1. Tracking the highest colony version available in the network
 2. Tracking the current versions of individual colonies 

To achieve 1), we listen to the `ColonyVersionAdded` event and utilise the existing `CurrentVersion` model already used for tracking highest available extension versions:
```gql
type CurrentVersion @model {
  id: ID!
  key: String! @index(name: "byKey", queryField: "getCurrentVersionByKey")
  version: Int!
}
```

For extensions, `key` represents the extension hash, in case of colonies, since there's only one type to track, `key` is set to `colony` string.

Additionally, we write the current highest version to the db on ingestor startup.

For 2), there is a new `version` field on Colony model that gets updated on `ColonyUpgraded` event. In the corresponding [CDapp PR](https://github.com/JoinColony/colonyCDapp/pull/163), you'll see the field added to the schema as well as colony creation mutation modified to include it.

## Testing

### Common steps
1. (CDapp directory) Run `git checkout feat/102-track-colony-version`
2. (CDapp) Apply the following patch:
```
diff --git a/docker/colony-cdapp-dev-env-orchestration.yaml b/docker/colony-cdapp-dev-env-orchestration.yaml
index 6e2a133..f319cc6 100644
--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -28,19 +28,19 @@ services:
     links:
     - "network-contracts:network-contracts.docker"
 
-  block-ingestor:
-    container_name: 'ingestor'
-    image: colony-cdapp-dev-env/block-ingestor:latest
-    volumes:
-      - '../amplify/mock-data:/colonyCDapp/amplify/mock-data'
-    ports:
-      - '10001:10001'
-    depends_on:
-      network-contracts:
-        condition: service_healthy
-    links:
-      - "network-contracts:network-contracts.docker"
-      - "amplify:amplify.docker"
+  # block-ingestor:
+  #   container_name: 'ingestor'
+  #   image: colony-cdapp-dev-env/block-ingestor:latest
+  #   volumes:
+  #     - '../amplify/mock-data:/colonyCDapp/amplify/mock-data'
+  #   ports:
+  #     - '10001:10001'
+  #   depends_on:
+  #     network-contracts:
+  #       condition: service_healthy
+  #   links:
+  #     - "network-contracts:network-contracts.docker"
+  #     - "amplify:amplify.docker"
 
   amplify:
     container_name: 'amplify'

```
3. (CDapp) Run `npm run dev`.
4. (block-ingestor directory) Run `npm run dev`.
5. (CDapp) Run `node scripts/temp-create-data.js`

### Storing the current colony version on ingestor start
1. Run `listCurrentVersions` query, e.g.:
```gql
query ListCurrentVersions {
  listCurrentVersions {
    items {
      key
      version
    }
  }
}
```
You should see an entry with key `colony` and `version` set to 10.

### Storing the colony version when new version is added to network
1. (CDapp) Run `npm run truffle console` and paste the following code line-by-line:
```js
// local dev ether router address
n = await IColonyNetwork.at('0x5CC4a96B08e8C88f2c6FC5772496FeD9666e4D1F')
// metacolony address
ma = await n.getMetaColony()
// metacolony instance
m = await IMetaColony.at(ma)
// get current version (10) resolver address
r = await n.getColonyVersionResolver(10)
// add new colony version (11) with previous version's resolver:
m.addNetworkColonyVersion(11, r)
```
You should see some logs in block-ingestor confirming it has picked up the event and if you run the `listCurrentVersions` query again, you should see the colony version updated.

### Tracking the individual colony version when colony is upgraded
1. Run the `listCurrentVersions` query. You should see an entry with key `0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c3` which is the address of the first dev colony (and the one we will be upgrading in the next step). Its version should be 10.
2. (CDapp) Run `npm run truffle console`, paste the code from the previous steps and add the following:
```js
// first local dev colony
c = await IColony.at('0x3a157280ca91bB49dAe3D1619C55Da7F9D4438c3')
// upgrade colony to version 11
c.upgrade(11)
```
Again, you should see some logs in block-ingestor console. Run `listCurrentVersions` again to verify that the colony version has been updated in the database.
