### PR TITLE
Write extension data to the db on ingestor start

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,9 @@
+import { Extension } from '@colony/colony-js';
+
 export const COLONY_CURRENT_VERSION_KEY = 'colony';
+
+export const SUPPORTED_EXTENSION_IDS = [
+  Extension.OneTxPayment,
+  Extension.VotingReputation,
+];
+export const INITIALISABLE_EXTENSION_IDS = [Extension.VotingReputation];

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -1,3 +1,5 @@
+import { getExtensionHash } from '@colony/colony-js';
+
 import {
   addColonyEventListener,
   addExtensionEventListener,
@@ -5,6 +7,7 @@ import {
   addTokenEventListener,
 } from './utils';
 import { ContractEventsSignatures } from './types';
+import { INITIALISABLE_EXTENSION_IDS } from './constants';
 
 /*
  * All events that need to be tracked on a single colony go in here
@@ -26,11 +29,17 @@ export const colonySpecificEventsListener = async (
 
 export const extensionSpecificEventsListener = async (
   extensionAddress: string,
+  extensionHash: string,
 ): Promise<void> => {
-  await addExtensionEventListener(
-    ContractEventsSignatures.ExtensionInitialised,
-    extensionAddress,
+  const isInitialisable = INITIALISABLE_EXTENSION_IDS.some(
+    (extensionId) => getExtensionHash(extensionId) === extensionHash,
   );
+  if (isInitialisable) {
+    await addExtensionEventListener(
+      ContractEventsSignatures.ExtensionInitialised,
+      extensionAddress,
+    );
+  }
 };
 
 const eventListener = async (): Promise<void> => {

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -260,19 +260,19 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionAddedToNetwork: {
-      const { extensionId, version } = event.args;
+      const { extensionId: extensionHash, version } = event.args;
       const convertedVersion = BigNumber.from(version).toNumber();
 
       verbose(
         'Extension:',
-        extensionId,
+        extensionHash,
         `(version ${convertedVersion})`,
         'added to network',
       );
 
       await mutate('setCurrentVersion', {
         input: {
-          key: extensionId,
+          key: extensionHash,
           version: convertedVersion,
         },
       });
@@ -281,37 +281,37 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionInstalled: {
-      const { extensionId, colony, version } = event.args;
+      const { extensionId: extensionHash, colony, version } = event.args;
       const convertedVersion = BigNumber.from(version).toNumber();
 
       const extensionAddress = await networkClient.getExtensionInstallation(
-        extensionId,
+        extensionHash,
         colony,
       );
 
       verbose(
         'Extension:',
-        extensionId,
+        extensionHash,
         `(version ${convertedVersion})`,
         'installed in Colony:',
         colony,
       );
 
       await writeExtensionFromEvent(event, extensionAddress);
-      await extensionSpecificEventsListener(extensionAddress);
+      await extensionSpecificEventsListener(extensionAddress, extensionHash);
 
       return;
     }
 
     case ContractEventsSignatures.ExtensionUninstalled: {
-      const { extensionId, colony } = event.args;
+      const { extensionId: extensionHash, colony } = event.args;
 
-      verbose('Extension:', extensionId, 'uninstalled in Colony:', colony);
+      verbose('Extension:', extensionHash, 'uninstalled in Colony:', colony);
 
       await mutate('updateColonyExtensionByColonyAndHash', {
         input: {
           colonyId: colony,
-          hash: extensionId,
+          hash: extensionHash,
           isDeleted: true,
         },
       });
@@ -320,11 +320,11 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionDeprecated: {
-      const { extensionId, colony, deprecated } = event.args;
+      const { extensionId: extensionHash, colony, deprecated } = event.args;
 
       verbose(
         'Extension:',
-        extensionId,
+        extensionHash,
         deprecated ? 'deprecated' : 're-enabled',
         'in Colony:',
         colony,
@@ -333,7 +333,7 @@ export default async (event: ContractEvent): Promise<void> => {
       await mutate('updateColonyExtensionByColonyAndHash', {
         input: {
           colonyId: colony,
-          hash: extensionId,
+          hash: extensionHash,
           isDeprecated: deprecated,
         },
       });
@@ -342,12 +342,12 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionUpgraded: {
-      const { extensionId, colony, version } = event.args;
+      const { extensionId: extensionHash, colony, version } = event.args;
       const convertedVersion = BigNumber.from(version).toNumber();
 
       verbose(
         'Extension:',
-        extensionId,
+        extensionHash,
         'upgraded to version',
         convertedVersion,
         'in Colony:',
@@ -357,7 +357,7 @@ export default async (event: ContractEvent): Promise<void> => {
       await mutate('updateColonyExtensionByColonyAndHash', {
         input: {
           colonyId: colony,
-          hash: extensionId,
+          hash: extensionHash,
           version: convertedVersion,
         },
       });

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -5,6 +5,7 @@ import {
   output,
   verbose,
   writeExtensionFromEvent,
+  writeExtensionVersionFromEvent,
   writeJsonStats,
 } from './utils';
 import { coloniesSet } from './trackColonies';
@@ -260,46 +261,19 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionAddedToNetwork: {
-      const { extensionId: extensionHash, version } = event.args;
-      const convertedVersion = BigNumber.from(version).toNumber();
-
-      verbose(
-        'Extension:',
-        extensionHash,
-        `(version ${convertedVersion})`,
-        'added to network',
-      );
-
-      await mutate('setCurrentVersion', {
-        input: {
-          key: extensionHash,
-          version: convertedVersion,
-        },
-      });
-
+      await writeExtensionVersionFromEvent(event);
       return;
     }
 
     case ContractEventsSignatures.ExtensionInstalled: {
-      const { extensionId: extensionHash, colony, version } = event.args;
-      const convertedVersion = BigNumber.from(version).toNumber();
-
+      const { extensionId: extensionHash, colony } = event.args;
       const extensionAddress = await networkClient.getExtensionInstallation(
         extensionHash,
         colony,
       );
 
-      verbose(
-        'Extension:',
-        extensionHash,
-        `(version ${convertedVersion})`,
-        'installed in Colony:',
-        colony,
-      );
-
       await writeExtensionFromEvent(event, extensionAddress);
       await extensionSpecificEventsListener(extensionAddress, extensionHash);
-
       return;
     }
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -2,6 +2,7 @@ import dotenv from 'dotenv';
 import { constants, BigNumber } from 'ethers';
 
 import {
+  deleteExtensionFromEvent,
   output,
   toNumber,
   verbose,
@@ -279,18 +280,7 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionUninstalled: {
-      const { extensionId: extensionHash, colony } = event.args;
-
-      verbose('Extension:', extensionHash, 'uninstalled in Colony:', colony);
-
-      await mutate('updateColonyExtensionByColonyAndHash', {
-        input: {
-          colonyId: colony,
-          hash: extensionHash,
-          isDeleted: true,
-        },
-      });
-
+      await deleteExtensionFromEvent(event);
       return;
     }
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -3,6 +3,7 @@ import { constants, BigNumber } from 'ethers';
 
 import {
   output,
+  toNumber,
   verbose,
   writeExtensionFromEvent,
   writeExtensionVersionFromEvent,
@@ -225,7 +226,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ColonyVersionAdded: {
       const { version } = event.args;
-      const convertedVersion = BigNumber.from(version).toNumber();
+      const convertedVersion = toNumber(version);
 
       verbose('New colony version:', convertedVersion, 'added to network');
 
@@ -242,7 +243,7 @@ export default async (event: ContractEvent): Promise<void> => {
     case ContractEventsSignatures.ColonyUpgraded: {
       const { contractAddress } = event;
       const { newVersion } = event.args;
-      const convertedVersion = BigNumber.from(newVersion).toNumber();
+      const convertedVersion = toNumber(newVersion);
 
       verbose(
         'Colony:',
@@ -317,7 +318,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExtensionUpgraded: {
       const { extensionId: extensionHash, colony, version } = event.args;
-      const convertedVersion = BigNumber.from(version).toNumber();
+      const convertedVersion = toNumber(version);
 
       verbose(
         'Extension:',

--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -1,6 +1,5 @@
 import dotenv from 'dotenv';
 import { getLogs } from '@colony/colony-js';
-import { BigNumber } from 'ethers';
 
 import networkClient from './networkClient';
 import {
@@ -9,6 +8,7 @@ import {
   verbose,
   addNetworkEventListener,
   setToJS,
+  toNumber,
 } from './utils';
 import { colonySpecificEventsListener } from './eventListener';
 import { ContractEventsSignatures } from './types';
@@ -76,7 +76,7 @@ const writeCurrentNetworkColonyVersion = async (): Promise<void> => {
   await mutate('setCurrentVersion', {
     input: {
       key: COLONY_CURRENT_VERSION_KEY,
-      version: BigNumber.from(version).toNumber(),
+      version: toNumber(version),
     },
   });
 };

--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -32,7 +32,7 @@ export default async (): Promise<void> => {
     networkClient.filters.ColonyAdded(),
   );
 
-  colonyAddedLogs.map((log) => {
+  colonyAddedLogs.forEach((log) => {
     const {
       args: { colonyAddress, token: tokenAddress },
     } = networkClient.interface.parseLog(log) || {};
@@ -42,7 +42,6 @@ export default async (): Promise<void> => {
      * - We're using a JSON string since we need to store two values, colony address and token
      */
     colonies.add(JSON.stringify({ colonyAddress, tokenAddress }));
-    return null;
   });
 
   await writeJsonStats({ trackedColonies: colonies.size });

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -25,10 +25,8 @@ export default async (): Promise<void> => {
     );
     await trackExtensionAddedToNetwork(extensionId, latestBlock);
 
-    verbose(
-      `Fetching events for extension: ${extensionId} starting from block: ${latestBlock}`,
-    );
-    await trackExtensionEvents(extensionId, latestBlock);
+    verbose(`Fetching events for extension: ${extensionId}`);
+    await trackExtensionEvents(extensionId);
   });
 };
 
@@ -61,10 +59,7 @@ const trackExtensionAddedToNetwork = async (
   writeExtensionVersionFromEvent(event);
 };
 
-const trackExtensionEvents = async (
-  extensionId: Extension,
-  latestBlock: number,
-): Promise<void> => {
+const trackExtensionEvents = async (extensionId: Extension): Promise<void> => {
   const extensionHash = getExtensionHash(extensionId);
   const extensionInstalledLogs = await getLogs(
     networkClient,
@@ -103,9 +98,7 @@ const trackExtensionEvents = async (
     installedInColonyCount,
   )) {
     /**
-     * If installation count is 0, that means the extension has been deleted,
-     * or never installed (but we'll try to delete it from the db anyway,
-     * to save a get query)
+     * If installation count is 0, that means the extension has been uninstalled
      */
     if (installationsCount <= 0) {
       const mostRecentUninstalledLog =

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -1,36 +1,29 @@
-import { Extension, getExtensionHash, getLogs } from '@colony/colony-js';
-import { Log } from '@ethersproject/providers';
+import { getExtensionHash, getLogs } from '@colony/colony-js';
+import { BigNumber } from 'ethers';
 
 import { extensionSpecificEventsListener } from './eventListener';
 import networkClient from './networkClient';
 import {
+  isExtensionDeprecated,
   mapLogToContractEvent,
   verbose,
   writeExtensionFromEvent,
 } from './utils';
-
-/**
- * Defines extensions for which we want to track ExtensionInitialised events
- * Note: If an extension config in CDapp doesn't specify initialization params,
- * it is considered enabled straight after installation and we don't need
- * to track ExtensionInitialised events for it (e.g. OneTxPayment)
- */
-const supportedExtensionIds = [getExtensionHash(Extension.VotingReputation)];
+import { SUPPORTED_EXTENSION_IDS } from './constants';
 
 export default async (): Promise<void> => {
   verbose('Fetching already installed extensions');
 
-  supportedExtensionIds.forEach(async (extensionId) => {
+  SUPPORTED_EXTENSION_IDS.forEach(async (extensionId) => {
+    const extensionHash = getExtensionHash(extensionId);
     const extensionInstalledLogs = await getLogs(
       networkClient,
-      networkClient.filters.ExtensionInstalled(extensionId),
+      networkClient.filters.ExtensionInstalled(extensionHash),
     );
     const extensionUninstalledLogs = await getLogs(
       networkClient,
-      networkClient.filters.ExtensionUninstalled(extensionId),
+      networkClient.filters.ExtensionUninstalled(extensionHash),
     );
-    // Store the most recent extension installed parsed log (needed below)
-    let lastInstalledLog: Log | undefined;
 
     /**
      * Looping through the logs to create a mapping between colonies
@@ -38,7 +31,6 @@ export default async (): Promise<void> => {
      */
     const installedInColonyCount: { [address: string]: number } = {};
     extensionInstalledLogs.forEach((log) => {
-      lastInstalledLog = log;
       const parsedLog = networkClient.interface.parseLog(log);
       const { colony } = parsedLog.args;
 
@@ -65,22 +57,45 @@ export default async (): Promise<void> => {
     )) {
       if (installationsCount > 0) {
         const extensionAddress = await networkClient.getExtensionInstallation(
-          extensionId,
+          extensionHash,
           colony,
         );
 
-        await extensionSpecificEventsListener(extensionAddress);
+        // Listen to extension specific events (e.g. ExtensionInitialised)
+        await extensionSpecificEventsListener(extensionAddress, extensionHash);
 
         // Store the most recent installation in the db
-        if (lastInstalledLog) {
-          const event = await mapLogToContractEvent(
+        const lastInstalledLog =
+          extensionInstalledLogs[extensionInstalledLogs.length - 1];
+        const event = await mapLogToContractEvent(
+          lastInstalledLog,
+          networkClient.interface,
+        );
+
+        if (event) {
+          /**
+           * Get the currently installed version of extension
+           * (so we don't have to worry about ExtensionUpgraded events)
+           */
+          const version = await (
+            await (
+              await networkClient.getColonyClient(colony)
+            ).getExtensionClient(extensionId)
+          ).version();
+          const convertedVersion = BigNumber.from(version).toNumber();
+
+          const isDeprecated = await isExtensionDeprecated(
+            extensionHash,
+            colony,
             lastInstalledLog,
-            networkClient.interface,
           );
 
-          if (event) {
-            await writeExtensionFromEvent(event, extensionAddress);
-          }
+          await writeExtensionFromEvent(
+            event,
+            extensionAddress,
+            convertedVersion,
+            isDeprecated,
+          );
         }
       }
     }

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -16,7 +16,7 @@ import stats from '../run/stats.json';
 import { extensionSpecificEventsListener } from './eventListener';
 
 export default async (): Promise<void> => {
-  const latestBlock = stats.latestBlock ?? 0;
+  const latestBlock = stats.latestBlock ?? 1;
 
   SUPPORTED_EXTENSION_IDS.forEach(async (extensionId) => {
     verbose(
@@ -82,7 +82,7 @@ const trackExtensionEvents = async (
     const { colony } = parsedLog.args;
 
     if (colony in installedInColonyCount) {
-      installedInColonyCount[colony]++;
+      installedInColonyCount[colony] += 1;
     } else {
       installedInColonyCount[colony] = 1;
     }
@@ -92,7 +92,7 @@ const trackExtensionEvents = async (
     const { colony } = parsedLog.args;
 
     if (colony in installedInColonyCount) {
-      installedInColonyCount[colony]--;
+      installedInColonyCount[colony] -= 1;
     }
   });
 

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -1,4 +1,4 @@
-import { getExtensionHash, getLogs } from '@colony/colony-js';
+import { Extension, getExtensionHash, getLogs } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
 
 import { extensionSpecificEventsListener } from './eventListener';
@@ -12,92 +12,100 @@ import {
 import { SUPPORTED_EXTENSION_IDS } from './constants';
 
 export default async (): Promise<void> => {
-  verbose('Fetching already installed extensions');
+  verbose('Fetching existing extensions');
 
   SUPPORTED_EXTENSION_IDS.forEach(async (extensionId) => {
-    const extensionHash = getExtensionHash(extensionId);
-    const extensionInstalledLogs = await getLogs(
-      networkClient,
-      networkClient.filters.ExtensionInstalled(extensionHash),
-    );
-    const extensionUninstalledLogs = await getLogs(
-      networkClient,
-      networkClient.filters.ExtensionUninstalled(extensionHash),
-    );
+    trackExtensionInstallations(extensionId);
+  });
+};
 
-    /**
-     * Looping through the logs to create a mapping between colonies
-     * and the number of extension installations we encounter, minus uninstallations
-     */
-    const installedInColonyCount: { [address: string]: number } = {};
-    extensionInstalledLogs.forEach((log) => {
-      const parsedLog = networkClient.interface.parseLog(log);
-      const { colony } = parsedLog.args;
+const trackExtensionInstallations = async (
+  extensionId: Extension,
+): Promise<void> => {
+  const extensionHash = getExtensionHash(extensionId);
+  const extensionInstalledLogs = await getLogs(
+    networkClient,
+    networkClient.filters.ExtensionInstalled(extensionHash),
+  );
+  const extensionUninstalledLogs = await getLogs(
+    networkClient,
+    networkClient.filters.ExtensionUninstalled(extensionHash),
+  );
 
-      if (colony in installedInColonyCount) {
-        installedInColonyCount[colony]++;
-      } else {
-        installedInColonyCount[colony] = 1;
-      }
-    });
-    extensionUninstalledLogs.forEach((log) => {
-      const parsedLog = networkClient.interface.parseLog(log);
-      const { colony } = parsedLog.args;
+  /**
+   * Looping through the logs to create a mapping between colonies
+   * and the number of extension installations we encounter, minus uninstallations
+   */
+  const installedInColonyCount: { [address: string]: number } = {};
+  extensionInstalledLogs.forEach((log) => {
+    const parsedLog = networkClient.interface.parseLog(log);
+    const { colony } = parsedLog.args;
 
-      if (colony in installedInColonyCount) {
-        installedInColonyCount[colony]--;
-      }
-    });
+    if (colony in installedInColonyCount) {
+      installedInColonyCount[colony]++;
+    } else {
+      installedInColonyCount[colony] = 1;
+    }
+  });
+  extensionUninstalledLogs.forEach((log) => {
+    const parsedLog = networkClient.interface.parseLog(log);
+    const { colony } = parsedLog.args;
 
+    if (colony in installedInColonyCount) {
+      installedInColonyCount[colony]--;
+    }
+  });
+
+  for (const [colony, installationsCount] of Object.entries(
+    installedInColonyCount,
+  )) {
     /**
      * Only the colonies with installation count > 0 have this extension currently installed
      */
-    for (const [colony, installationsCount] of Object.entries(
-      installedInColonyCount,
-    )) {
-      if (installationsCount > 0) {
-        const extensionAddress = await networkClient.getExtensionInstallation(
-          extensionHash,
-          colony,
-        );
-
-        // Listen to extension specific events (e.g. ExtensionInitialised)
-        await extensionSpecificEventsListener(extensionAddress, extensionHash);
-
-        // Store the most recent installation in the db
-        const lastInstalledLog =
-          extensionInstalledLogs[extensionInstalledLogs.length - 1];
-        const event = await mapLogToContractEvent(
-          lastInstalledLog,
-          networkClient.interface,
-        );
-
-        if (event) {
-          /**
-           * Get the currently installed version of extension
-           * (so we don't have to worry about ExtensionUpgraded events)
-           */
-          const version = await (
-            await (
-              await networkClient.getColonyClient(colony)
-            ).getExtensionClient(extensionId)
-          ).version();
-          const convertedVersion = BigNumber.from(version).toNumber();
-
-          const isDeprecated = await isExtensionDeprecated(
-            extensionHash,
-            colony,
-            lastInstalledLog,
-          );
-
-          await writeExtensionFromEvent(
-            event,
-            extensionAddress,
-            convertedVersion,
-            isDeprecated,
-          );
-        }
-      }
+    if (installationsCount === 0) {
+      continue;
     }
-  });
+
+    const extensionAddress = await networkClient.getExtensionInstallation(
+      extensionHash,
+      colony,
+    );
+
+    // Listen to extension specific events (e.g. ExtensionInitialised)
+    await extensionSpecificEventsListener(extensionAddress, extensionHash);
+
+    // Store the most recent installation in the db
+    const lastInstalledLog =
+      extensionInstalledLogs[extensionInstalledLogs.length - 1];
+    const event = await mapLogToContractEvent(
+      lastInstalledLog,
+      networkClient.interface,
+    );
+
+    if (event) {
+      /**
+       * Get the currently installed version of extension
+       * (so we don't have to worry about ExtensionUpgraded events)
+       */
+      const version = await (
+        await (
+          await networkClient.getColonyClient(colony)
+        ).getExtensionClient(extensionId)
+      ).version();
+      const convertedVersion = BigNumber.from(version).toNumber();
+
+      const isDeprecated = await isExtensionDeprecated(
+        extensionHash,
+        colony,
+        lastInstalledLog,
+      );
+
+      await writeExtensionFromEvent(
+        event,
+        extensionAddress,
+        convertedVersion,
+        isDeprecated,
+      );
+    }
+  }
 };

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -1,5 +1,4 @@
 import { Extension, getExtensionHash, getLogs } from '@colony/colony-js';
-import { BigNumber } from 'ethers';
 
 import { extensionSpecificEventsListener } from './eventListener';
 import networkClient from './networkClient';
@@ -7,6 +6,7 @@ import {
   isExtensionDeprecated,
   isExtensionInitialised,
   mapLogToContractEvent,
+  toNumber,
   verbose,
   writeExtensionFromEvent,
   writeExtensionVersionFromEvent,
@@ -123,7 +123,7 @@ const trackExtensionInstallations = async (
           await networkClient.getColonyClient(colony)
         ).getExtensionClient(extensionId)
       ).version();
-      const convertedVersion = BigNumber.from(version).toNumber();
+      const convertedVersion = toNumber(version);
 
       const isDeprecated = await isExtensionDeprecated(
         extensionHash,

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -5,6 +5,7 @@ import { extensionSpecificEventsListener } from './eventListener';
 import networkClient from './networkClient';
 import {
   isExtensionDeprecated,
+  isExtensionInitialised,
   mapLogToContractEvent,
   verbose,
   writeExtensionFromEvent,
@@ -13,11 +14,12 @@ import {
 import { SUPPORTED_EXTENSION_IDS } from './constants';
 
 export default async (): Promise<void> => {
-  verbose('Fetching existing extensions');
-
   SUPPORTED_EXTENSION_IDS.forEach(async (extensionId) => {
-    await trackExtensionInstallations(extensionId);
+    verbose(`Fetching current version of extension: ${extensionId}`);
     await trackExtensionAddedToNetwork(extensionId);
+
+    verbose(`Fetching existing installations of extension: ${extensionId}`);
+    await trackExtensionInstallations(extensionId);
   });
 };
 
@@ -129,11 +131,17 @@ const trackExtensionInstallations = async (
         mostRecentInstalledLog,
       );
 
+      const isInitialised = await isExtensionInitialised(
+        extensionAddress,
+        mostRecentInstalledLog,
+      );
+
       await writeExtensionFromEvent(
         event,
         extensionAddress,
         convertedVersion,
         isDeprecated,
+        isInitialised,
       );
     }
   }

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -1,12 +1,20 @@
 import { BigNumber, constants } from 'ethers';
+import { Log } from '@ethersproject/providers';
+import { getLogs } from '@colony/colony-js';
 
 import networkClient from '../networkClient';
 import { mutate } from '../amplifyClient';
 import { ContractEvent } from '../types';
 
+/**
+ * Function extracting installed extension details from the event and writing it to the database
+ * @param overrideVersion If set, it will be used instead of the version in the event arguments
+ */
 export const writeExtensionFromEvent = async (
   event: ContractEvent,
   extensionAddress: string,
+  overrideVersion?: number,
+  isDeprecated?: boolean,
 ): Promise<void> => {
   const { transactionHash, timestamp } = event;
   const { extensionId, colony, version } = event.args;
@@ -22,12 +30,41 @@ export const writeExtensionFromEvent = async (
       id: extensionAddress,
       colonyId: colony,
       hash: extensionId,
-      version: convertedVersion,
+      version: overrideVersion ?? convertedVersion,
       installedBy,
       installedAt: timestamp,
-      isDeprecated: false,
+      isDeprecated: !!isDeprecated,
       isDeleted: false,
       isInitialized: false,
     },
   });
+};
+
+/**
+ * Function determining whether an extension has been deprecated in colony
+ * since its installation, based on the ExtensionInstalled event log
+ */
+export const isExtensionDeprecated = async (
+  extensionHash: string,
+  colonyAddress: string,
+  installedLog: Log,
+): Promise<boolean> => {
+  const extensionDeprecatedLogs = await getLogs(
+    networkClient,
+    networkClient.filters.ExtensionDeprecated(extensionHash, colonyAddress),
+  );
+  const lastDeprecatedLog =
+    extensionDeprecatedLogs[extensionDeprecatedLogs.length - 1];
+
+  // Short-circuit if there's no log or it happened before the installation
+  if (
+    !lastDeprecatedLog ||
+    lastDeprecatedLog.blockNumber < installedLog.blockNumber
+  ) {
+    return false;
+  }
+
+  const parsedLog = await networkClient.interface.parseLog(lastDeprecatedLog);
+
+  return !!parsedLog.args.deprecated;
 };

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -1,4 +1,4 @@
-import { BigNumber, constants, Contract } from 'ethers';
+import { constants, Contract } from 'ethers';
 import { Log } from '@ethersproject/providers';
 import { getLogs } from '@colony/colony-js';
 
@@ -6,6 +6,7 @@ import networkClient from '../networkClient';
 import { mutate } from '../amplifyClient';
 import { ContractEvent, ContractEventsSignatures } from '../types';
 import { verbose } from './logger';
+import { toNumber } from './numbers';
 
 /**
  * Function writing the extension version to the db based on the ExtensionAddedToNetwork event payload
@@ -14,7 +15,7 @@ export const writeExtensionVersionFromEvent = async (
   event: ContractEvent,
 ): Promise<void> => {
   const { version, extensionId: extensionHash } = event.args;
-  const convertedVersion = BigNumber.from(version).toNumber();
+  const convertedVersion = toNumber(version);
 
   verbose(
     'Extension:',
@@ -44,7 +45,7 @@ export const writeExtensionFromEvent = async (
 ): Promise<void> => {
   const { transactionHash, timestamp } = event;
   const { extensionId: extensionHash, colony, version } = event.args;
-  const convertedVersion = BigNumber.from(version).toNumber();
+  const convertedVersion = toNumber(version);
 
   const receipt = await networkClient.provider.getTransactionReceipt(
     transactionHash,

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -75,6 +75,22 @@ export const writeExtensionFromEvent = async (
   });
 };
 
+export const deleteExtensionFromEvent = async (
+  event: ContractEvent,
+): Promise<void> => {
+  const { extensionId: extensionHash, colony } = event.args;
+
+  verbose('Extension:', extensionHash, 'uninstalled in Colony:', colony);
+
+  await mutate('updateColonyExtensionByColonyAndHash', {
+    input: {
+      colonyId: colony,
+      hash: extensionHash,
+      isDeleted: true,
+    },
+  });
+};
+
 /**
  * Function determining whether an extension has been deprecated in colony
  * since its installation, based on the ExtensionInstalled event log

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -35,6 +35,8 @@ export const writeExtensionVersionFromEvent = async (
 /**
  * Function extracting installed extension details from the event and writing it to the database
  * @param overrideVersion If set, it will be used instead of the version in the event arguments
+ * @param shouldUpsert If true, the function will call updateExtensionByColonyAndHash mutation
+ * instead of createColonyExtension
  */
 export const writeExtensionFromEvent = async (
   event: ContractEvent,
@@ -76,8 +78,7 @@ export const writeExtensionFromEvent = async (
     await mutate('updateColonyExtensionByColonyAndHash', {
       input,
     });
-  }
-  {
+  } else {
     await mutate('createColonyExtension', {
       input: {
         id: extensionAddress,

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -1,0 +1,33 @@
+import { BigNumber, constants } from 'ethers';
+
+import networkClient from '../networkClient';
+import { mutate } from '../amplifyClient';
+import { ContractEvent } from '../types';
+
+export const writeExtensionFromEvent = async (
+  event: ContractEvent,
+  extensionAddress: string,
+): Promise<void> => {
+  const { transactionHash, timestamp } = event;
+  const { extensionId, colony, version } = event.args;
+  const convertedVersion = BigNumber.from(version).toNumber();
+
+  const receipt = await networkClient.provider.getTransactionReceipt(
+    transactionHash,
+  );
+  const installedBy = receipt.from || constants.AddressZero;
+
+  await mutate('createColonyExtension', {
+    input: {
+      id: extensionAddress,
+      colonyId: colony,
+      hash: extensionId,
+      version: convertedVersion,
+      installedBy,
+      installedAt: timestamp,
+      isDeprecated: false,
+      isDeleted: false,
+      isInitialized: false,
+    },
+  });
+};

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -87,6 +87,9 @@ export const isExtensionDeprecated = async (
   const extensionDeprecatedLogs = await getLogs(
     networkClient,
     networkClient.filters.ExtensionDeprecated(extensionHash, colonyAddress),
+    {
+      fromBlock: installedLog.blockNumber,
+    },
   );
   const mostRecentDeprecatedLog =
     extensionDeprecatedLogs[extensionDeprecatedLogs.length - 1];
@@ -114,10 +117,16 @@ export const isExtensionInitialised = async (
     `event ${ContractEventsSignatures.ExtensionInitialised}`,
   ]);
 
-  const extensionInitialisedLogs = await getLogs(networkClient, {
-    topics: extensionContract.filters.ExtensionInitialised().topics,
-    address: extensionAddress,
-  });
+  const extensionInitialisedLogs = await getLogs(
+    networkClient,
+    {
+      topics: extensionContract.filters.ExtensionInitialised().topics,
+      address: extensionAddress,
+    },
+    {
+      fromBlock: installedLog.blockNumber,
+    },
+  );
   const mostRecentInitialisedLog =
     extensionInitialisedLogs[extensionInitialisedLogs.length - 1];
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './logger';
+export * from './events';
+export * from './stats';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './logger';
 export * from './events';
 export * from './stats';
+export * from './extensions';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './logger';
 export * from './events';
 export * from './stats';
 export * from './extensions';
+export * from './numbers';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,18 @@
+/*
+ * Log to console with name and timestamp
+ * Used for basic stuff, which will always be logged
+ */
+export const output = (...messages: any[]): void =>
+  console.log(new Date().toJSON(), ...messages);
+
+/*
+ * Log to console with name and timestamp
+ * This should be added to internals, which you don't always want to show in production
+ * This is controlled by the `VERBOSE_OUTPUT` env variable
+ */
+export const verbose = (...messages: any[]): void => {
+  const verboseOutput = process.env.VERBOSE_OUTPUT === 'true';
+  if (verboseOutput) {
+    output(...messages);
+  }
+};

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,0 +1,4 @@
+import { BigNumber, BigNumberish } from 'ethers';
+
+export const toNumber = (bigNumber: BigNumberish): number =>
+  BigNumber.from(bigNumber).toNumber();

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,66 @@
+import { ensureFile, readJson, writeJson } from 'fs-extra';
+import path from 'path';
+
+import { verbose } from './logger';
+
+/*
+ * Read a json file at a specified path.
+ * If the file (including the path) doesn't exist, it will be created and seeded
+ * with an empty object
+ */
+export const readJsonStats = async (
+  filePath = `${path.resolve(__dirname, '..')}/run/stats.json`,
+): Promise<Record<string, unknown>> => {
+  await ensureFile(filePath);
+  let jsonContents;
+  try {
+    jsonContents = await readJson(filePath);
+    return jsonContents;
+  } catch (error) {
+    await writeJson(filePath, {});
+    return {};
+  }
+};
+
+type ObjectOrFunction =
+  | Record<string, unknown>
+  | ((jsonFile: Record<string, unknown>) => Record<string, unknown>);
+
+/*
+ * Write a json file at a specified path.
+ * It accepts either a object fragment (or full object) that will get appended to the existing file,
+ * or a callback (which receives the current version of the file) and needs to return the new object
+ * that will be written back
+ */
+export const writeJsonStats = async (
+  objectOrFunction: ObjectOrFunction,
+  filePath = `${path.resolve(__dirname, '..')}/run/stats.json`,
+): Promise<void> => {
+  const port = process.env.STATS_PORT;
+  if (!port) {
+    verbose('Stats are DISABLED, no point in writing to the stats file');
+    /*
+     * If the port isn't set, it means the stats are disabled, so there's no point
+     * in keep writing the stats file, so we exit early
+     */
+    return;
+  }
+
+  let newJsonContents = {};
+  const curentJsonContents = await readJsonStats(filePath);
+
+  if (typeof objectOrFunction === 'function') {
+    newJsonContents = {
+      ...curentJsonContents,
+      ...objectOrFunction(curentJsonContents),
+    };
+  } else {
+    newJsonContents = {
+      ...curentJsonContents,
+      ...objectOrFunction,
+    };
+  }
+
+  await writeJson(filePath, newJsonContents);
+  verbose('Stats file updated');
+};


### PR DESCRIPTION
This PR adds tracking of extension events that happened before block-ingestor has started, ensuring the db stays up to date.

The tracking logic can be split in two parts: tracking current extension version and tracking extension installation events.

Latest block number refers to the latest block processed by block-ingestor that is stored in `run/stats.json`.

## Tracking current extension version
For every supported extension, we fetch the `ExtensionAddedToNetwork` events, starting from the latest block processed by the block-ingestor. It takes the most recent event (since we only care about the most recent version anyway) and if exists, writes the version to the database.

## Tracking extension installation events
For every supported extension, we fetch **all** `ExtensionInstalled` and `ExtensionUninstalled` events and then create a mapping between colony address and the count of installations minus uninstallations. If the count is 0, that means the extension has been removed at some point (we wouldn't have an entry if it was never installed), otherwise we know it's currently installed.
In case of deleted extension, we compare the most recent deletion event with the latest block number, and if it happened after that, we delete the extension from the db.
In case of installed extension, we cannot simply do that comparison. There could be many other events that happened after the installation which must be reflected in the db - deprecation, upgrading, enabling. We can get the currently installed version from the chain directly, and I added util functions for determining deprecation and initialisation status. I modified the behaviour of `updateExtensionByColonyAndHash` so that it creates an extension if one doesn't exist, and I call that mutation for each installed extension to create or update the db entry with the most recent state.

## Testing
1. (CDapp directory) Run `git checkout feat/102-track-colony-version`
2. (CDapp) Apply the following patch:
```
diff --git a/docker/colony-cdapp-dev-env-orchestration.yaml b/docker/colony-cdapp-dev-env-orchestration.yaml
index 6e2a133..f319cc6 100644
--- a/docker/colony-cdapp-dev-env-orchestration.yaml
+++ b/docker/colony-cdapp-dev-env-orchestration.yaml
@@ -28,19 +28,19 @@ services:
     links:
     - "network-contracts:network-contracts.docker"
 
-  block-ingestor:
-    container_name: 'ingestor'
-    image: colony-cdapp-dev-env/block-ingestor:latest
-    volumes:
-      - '../amplify/mock-data:/colonyCDapp/amplify/mock-data'
-    ports:
-      - '10001:10001'
-    depends_on:
-      network-contracts:
-        condition: service_healthy
-    links:
-      - "network-contracts:network-contracts.docker"
-      - "amplify:amplify.docker"
+  # block-ingestor:
+  #   container_name: 'ingestor'
+  #   image: colony-cdapp-dev-env/block-ingestor:latest
+  #   volumes:
+  #     - '../amplify/mock-data:/colonyCDapp/amplify/mock-data'
+  #   ports:
+  #     - '10001:10001'
+  #   depends_on:
+  #     network-contracts:
+  #       condition: service_healthy
+  #   links:
+  #     - "network-contracts:network-contracts.docker"
+  #     - "amplify:amplify.docker"
 
   amplify:
     container_name: 'amplify'

```
3. (CDapp) Run `npm run dev`.

With block-ingestor not running, perform different actions on extensions: install, deprecate, enable, uninstall. Run block-ingestor with `npm run dev` (in block-ingestor directory) and refresh the CDapp to verify that the results of your actions have been stored in the db successfully. Disable block-ingestor again and perform another bunch of actions, focusing on e.g. deprecating a previously installed extension. Run block-ingestor and check the results.
