### PR TITLE
Add motion staking support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@colony/colony-js": "^6.1.0",
         "aws-amplify": "^4.3.43",
+        "decimal.js": "^10.4.3",
         "dotenv": "^16.0.3",
         "ethers": "^5.7.2",
         "express": "^4.18.2",
@@ -11413,6 +11414,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
@@ -27269,6 +27275,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "peer": true
+    },
+    "decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "decode-uri-component": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@colony/colony-js": "^6.1.0",
     "aws-amplify": "^4.3.43",
+    "decimal.js": "^10.4.3",
     "dotenv": "^16.0.3",
     "ethers": "^5.7.2",
     "express": "^4.18.2",

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -66,6 +66,7 @@ export const mutations = {
       $input: UpdateColonyExtensionInput!
     ) {
       updateColonyExtension(input: $input) {
+        id
         extensionHash: hash
         colonyAddress: colonyId
       }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -146,6 +146,44 @@ export const queries = {
       }
     }
   `,
+  getColonyMotions: /* GraphQL */ `
+    query GetActionsByColony($colonyAddress: ID!) {
+      getActionsByColony(
+        colonyId: $colonyAddress
+        filter: { isMotion: { eq: true } }
+      ) {
+        items {
+          id
+          motionData {
+            rootHash
+            motionStakes {
+              raw {
+                yay
+                nay
+              }
+              percentage {
+                yay
+                nay
+              }
+            }
+            usersStakes {
+              address
+              stakes {
+                raw {
+                  yay
+                  nay
+                }
+              }
+            }
+            motionState
+            motionDomainId
+            skillRep
+            motionId
+          }
+        }
+      }
+    }
+  `,
 };
 
 export default (): void => {

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -7,21 +7,26 @@ import {
   addTokenEventListener,
   addActionEventListeners,
   addMotionEventListener,
+  RemoveListener,
 } from './utils';
 import { ContractEventsSignatures } from './types';
 import { INITIALISABLE_EXTENSION_IDS } from './constants';
 
 export const motionSpecificEventsListener = async (
   colonyAddress: string,
-): Promise<void> => {
-  await addMotionEventListener(
-    ContractEventsSignatures.MotionCreated,
-    colonyAddress,
-  );
-  await addMotionEventListener(
-    ContractEventsSignatures.MotionStaked,
-    colonyAddress,
-  );
+): Promise<RemoveListener[]> => {
+  const removeListeners: RemoveListener[] = [
+    await addMotionEventListener(
+      ContractEventsSignatures.MotionCreated,
+      colonyAddress,
+    ),
+    await addMotionEventListener(
+      ContractEventsSignatures.MotionStaked,
+      colonyAddress,
+    ),
+  ];
+
+  return removeListeners;
 };
 /*
  * All events that need to be tracked on a single colony go in here

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -11,7 +11,9 @@ import {
 import { ContractEventsSignatures } from './types';
 import { INITIALISABLE_EXTENSION_IDS } from './constants';
 
-export const motionSpecificEventsListener = async (colonyAddress: string) => {
+export const motionSpecificEventsListener = async (
+  colonyAddress: string,
+): Promise<void> => {
   await addMotionEventListener(
     ContractEventsSignatures.MotionCreated,
     colonyAddress,

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -6,10 +6,21 @@ import {
   addNetworkEventListener,
   addTokenEventListener,
   addActionEventListeners,
+  addMotionEventListener,
 } from './utils';
 import { ContractEventsSignatures } from './types';
 import { INITIALISABLE_EXTENSION_IDS } from './constants';
 
+export const motionSpecificEventsListener = async (colonyAddress: string) => {
+  await addMotionEventListener(
+    ContractEventsSignatures.MotionCreated,
+    colonyAddress,
+  );
+  await addMotionEventListener(
+    ContractEventsSignatures.MotionStaked,
+    colonyAddress,
+  );
+};
 /*
  * All events that need to be tracked on a single colony go in here
  * as this will get linked in all the relevant places

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -23,7 +23,7 @@ import {
   handleMotionCreated,
   handleMotionStaked,
 } from './handlers';
-
+import { RemoveListener } from './utils';
 dotenv.config();
 
 /*
@@ -37,6 +37,17 @@ dotenv.config();
  *   return;
  * }
  */
+
+export interface EventProcessorContext {
+  removeListeners: {
+    [address: string]: {
+      [handler: string]: RemoveListener[];
+    };
+  };
+}
+
+const context: EventProcessorContext = { removeListeners: {} };
+
 export default async (event: ContractEvent): Promise<void> => {
   if (!event.signature) {
     throw new Error(
@@ -89,7 +100,7 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionUninstalled: {
-      await handleExtensionUninstalled(event);
+      await handleExtensionUninstalled(event, context);
       return;
     }
 
@@ -104,7 +115,7 @@ export default async (event: ContractEvent): Promise<void> => {
     }
 
     case ContractEventsSignatures.ExtensionInitialised: {
-      await handleExtensionInitialised(event);
+      await handleExtensionInitialised(event, context);
       return;
     }
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -21,6 +21,7 @@ import {
   handleEditColonyAction,
   handleVersionUpgradeAction,
   handleMotionCreated,
+  handleMotionStaked,
 } from './handlers';
 
 dotenv.config();
@@ -110,6 +111,11 @@ export default async (event: ContractEvent): Promise<void> => {
     /* Entry point for a newly created motion. */
     case ContractEventsSignatures.MotionCreated: {
       await handleMotionCreated(event);
+      return;
+    }
+
+    case ContractEventsSignatures.MotionStaked: {
+      await handleMotionStaked(event);
       return;
     }
 

--- a/src/handlers/extensions/extensionInitialised.ts
+++ b/src/handlers/extensions/extensionInitialised.ts
@@ -21,7 +21,7 @@ export default async (event: ContractEvent): Promise<void> => {
     },
   });
 
-  /* Listen for motions once Voting Reputation is enabled.*/
+  /* Listen for motions once Voting Reputation is enabled. */
   if (getExtensionHash(Extension.VotingReputation) === extensionHash) {
     await motionSpecificEventsListener(colonyAddress);
 

--- a/src/handlers/extensions/extensionInitialised.ts
+++ b/src/handlers/extensions/extensionInitialised.ts
@@ -1,12 +1,9 @@
 import { Extension, getExtensionHash } from '@colony/colony-js';
 
 import { mutate } from '~amplifyClient';
-import { ContractEvent, ContractEventsSignatures } from '~types';
-import {
-  addMotionEventListener,
-  verbose,
-  writeVotingReputationInitParamsToDB,
-} from '~utils';
+import { motionSpecificEventsListener } from '~eventListener';
+import { ContractEvent } from '~types';
+import { verbose, writeVotingReputationInitParamsToDB } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { contractAddress: extensionAddress } = event;
@@ -26,10 +23,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
   /* Listen for motions once Voting Reputation is enabled.*/
   if (getExtensionHash(Extension.VotingReputation) === extensionHash) {
-    await addMotionEventListener(
-      ContractEventsSignatures.MotionCreated,
-      colonyAddress,
-    );
+    await motionSpecificEventsListener(colonyAddress);
 
     /* Add Voting Extension Initialisation Params to DB for access by motions */
     await writeVotingReputationInitParamsToDB(id, colonyAddress);

--- a/src/handlers/extensions/extensionInitialised.ts
+++ b/src/handlers/extensions/extensionInitialised.ts
@@ -2,7 +2,11 @@ import { Extension, getExtensionHash } from '@colony/colony-js';
 
 import { mutate } from '~amplifyClient';
 import { ContractEvent, ContractEventsSignatures } from '~types';
-import { addMotionEventListener, verbose } from '~utils';
+import {
+  addMotionEventListener,
+  verbose,
+  writeVotingReputationInitParamsToDB,
+} from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { contractAddress: extensionAddress } = event;
@@ -11,7 +15,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
   const {
     data: {
-      updateColonyExtension: { extensionHash, colonyAddress },
+      updateColonyExtension: { id, extensionHash, colonyAddress },
     },
   } = await mutate('updateColonyExtensionByAddress', {
     input: {
@@ -26,5 +30,8 @@ export default async (event: ContractEvent): Promise<void> => {
       ContractEventsSignatures.MotionCreated,
       colonyAddress,
     );
+
+    /* Add Voting Extension Initialisation Params to DB for access by motions */
+    await writeVotingReputationInitParamsToDB(id, colonyAddress);
   }
 };

--- a/src/handlers/extensions/extensionUninstalled.ts
+++ b/src/handlers/extensions/extensionUninstalled.ts
@@ -1,6 +1,21 @@
+import { EventProcessorContext } from '~eventProcessor';
 import { ContractEvent } from '~types';
 import { deleteExtensionFromEvent } from '~utils';
+import { EXTENSION_INITIALISED_MOTION_LISTENERS } from './extensionInitialised';
 
-export default async (event: ContractEvent): Promise<void> => {
+export default async (
+  event: ContractEvent,
+  context: EventProcessorContext,
+): Promise<void> => {
+  const {
+    args: { colony: colonyAddress },
+  } = event;
   await deleteExtensionFromEvent(event);
+  const removeListeners =
+    context.removeListeners[colonyAddress]?.[
+      EXTENSION_INITIALISED_MOTION_LISTENERS
+    ];
+  removeListeners?.forEach((removeListener) => {
+    removeListener();
+  });
 };

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -1,19 +1,25 @@
 import Decimal from 'decimal.js';
 import { BigNumber } from 'ethers';
 import { mutate } from '~amplifyClient';
-import { MotionQuery, MotionSide, UserStake } from '~types';
+import {
+  MotionData,
+  MotionQuery,
+  MotionSide,
+  MotionStakes,
+  UserStake,
+} from '~types';
 import { convertStakeToPercentage } from '~utils';
 
 const getUpdatedUserStakesAmount = (
   existingAmount: string,
   amount: BigNumber,
-) => BigNumber.from(existingAmount).add(amount).toString();
+): string => BigNumber.from(existingAmount).add(amount).toString();
 
 const getUpdatedUserStake = (
   userStake: UserStake,
   side: MotionSide,
   amount: BigNumber,
-) => {
+): UserStake => {
   const existingAmount = userStake.stakes.raw[side];
   userStake.stakes.raw[side] = getUpdatedUserStakesAmount(
     existingAmount,
@@ -26,27 +32,34 @@ const getUserStakesMapFn =
   (staker: string, vote: BigNumber, amount: BigNumber) =>
   (userStake: UserStake) => {
     const { address } = userStake;
+    /* If the entry has the same address as the staker, we update the entry  */
     if (address === staker) {
       return getUpdatedUserStake(userStake, getMotionSide(vote), amount);
     }
 
+    /* Else, we just return as is */
     return userStake;
   };
 
+/** Takes the existing usersStakers db entry, and adds the latest information from the MotionStaked event. */
 const getUpdatedUsersStakes = (
   usersStakes: UserStake[],
   staker: string,
   vote: BigNumber,
   amount: BigNumber,
-) => {
+): UserStake[] => {
   const isExistingStaker = usersStakes.some(
     ({ address }) => address === staker,
   );
+
+  /* Has user already staked on this motion? */
   if (isExistingStaker) {
+    /* If so, update their entry in the usersStakes array. */
     const updateUserStakes = getUserStakesMapFn(staker, vote, amount);
     return usersStakes.map(updateUserStakes);
   }
 
+  /* If not, add their stake data to the end of the array. */
   const invertedVote = BigNumber.from(1).sub(vote);
   const newUserStake = {
     address: staker,
@@ -58,15 +71,16 @@ const getUpdatedUsersStakes = (
     },
   };
 
-  return [...usersStakes, newUserStake];
+  return [...usersStakes, newUserStake] as UserStake[];
 };
 
+/** Takes existing motionStakes db entry and updates it with latest information from MotionStaked event */
 const getUpdatedMotionStakes = (
-  motionStakes: MotionQuery['motionData']['motionStakes'],
+  motionStakes: MotionStakes,
   vote: BigNumber,
   amount: BigNumber,
   requiredStake: Decimal,
-) => {
+): MotionStakes => {
   const currentAmount = motionStakes.raw[getMotionSide(vote)];
   const updatedAmount = new Decimal(currentAmount).add(amount.toString());
   const updatedPercentage = convertStakeToPercentage(
@@ -86,12 +100,12 @@ const getUpdatedMotionStakes = (
 };
 
 const getUpdatedMotionData = (
-  motionData: MotionQuery['motionData'],
+  motionData: MotionData,
   vote: BigNumber,
   amount: BigNumber,
   staker: string,
   requiredStake: Decimal,
-) => {
+): MotionData => {
   const { motionStakes, usersStakes } = motionData;
   return {
     ...motionData,
@@ -111,7 +125,7 @@ export const updateMotionStakeInDB = async (
   amount: BigNumber,
   staker: string,
   requiredStake: Decimal,
-) => {
+): Promise<void> => {
   await mutate('updateColonyAction', {
     input: {
       id,
@@ -126,10 +140,5 @@ export const updateMotionStakeInDB = async (
   });
 };
 
-export const getMotionSide = (vote: BigNumber) => {
-  if (vote.eq(1)) {
-    return MotionSide.YAY;
-  }
-
-  return MotionSide.NAY;
-};
+export const getMotionSide = (vote: BigNumber): MotionSide =>
+  vote.eq(1) ? MotionSide.YAY : MotionSide.NAY;

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -1,0 +1,135 @@
+import Decimal from 'decimal.js';
+import { BigNumber } from 'ethers';
+import { mutate } from '~amplifyClient';
+import { MotionQuery, MotionSide, UserStake } from '~types';
+import { convertStakeToPercentage } from '~utils';
+
+const getUpdatedUserStakesAmount = (
+  existingAmount: string,
+  amount: BigNumber,
+) => BigNumber.from(existingAmount).add(amount).toString();
+
+const getUpdatedUserStake = (
+  userStake: UserStake,
+  side: MotionSide,
+  amount: BigNumber,
+) => {
+  const existingAmount = userStake.stakes.raw[side];
+  userStake.stakes.raw[side] = getUpdatedUserStakesAmount(
+    existingAmount,
+    amount,
+  );
+  return userStake;
+};
+
+const getUserStakesMapFn =
+  (staker: string, vote: BigNumber, amount: BigNumber) =>
+  (userStake: UserStake) => {
+    const { address } = userStake;
+    if (address === staker) {
+      return getUpdatedUserStake(userStake, getMotionSide(vote), amount);
+    }
+
+    return userStake;
+  };
+
+const getUpdatedUsersStakes = (
+  usersStakes: UserStake[],
+  staker: string,
+  vote: BigNumber,
+  amount: BigNumber,
+) => {
+  const isExistingStaker = usersStakes.some(
+    ({ address }) => address === staker,
+  );
+  if (isExistingStaker) {
+    const updateUserStakes = getUserStakesMapFn(staker, vote, amount);
+    return usersStakes.map(updateUserStakes);
+  }
+
+  const invertedVote = BigNumber.from(1).sub(vote);
+  const newUserStake = {
+    address: staker,
+    stakes: {
+      raw: {
+        [getMotionSide(vote)]: amount.toString(),
+        [getMotionSide(invertedVote)]: '0',
+      },
+    },
+  };
+
+  return [...usersStakes, newUserStake];
+};
+
+const getUpdatedMotionStakes = (
+  motionStakes: MotionQuery['motionData']['motionStakes'],
+  vote: BigNumber,
+  amount: BigNumber,
+  requiredStake: Decimal,
+) => {
+  const currentAmount = motionStakes.raw[getMotionSide(vote)];
+  const updatedAmount = new Decimal(currentAmount).add(amount.toString());
+  const updatedPercentage = convertStakeToPercentage(
+    updatedAmount,
+    requiredStake,
+  );
+  return {
+    raw: {
+      ...motionStakes.raw,
+      [getMotionSide(vote)]: updatedAmount.toString(),
+    },
+    percentage: {
+      ...motionStakes.percentage,
+      [getMotionSide(vote)]: updatedPercentage,
+    },
+  };
+};
+
+const getUpdatedMotionData = (
+  motionData: MotionQuery['motionData'],
+  vote: BigNumber,
+  amount: BigNumber,
+  staker: string,
+  requiredStake: Decimal,
+) => {
+  const { motionStakes, usersStakes } = motionData;
+  return {
+    ...motionData,
+    motionStakes: getUpdatedMotionStakes(
+      motionStakes,
+      vote,
+      amount,
+      requiredStake,
+    ),
+    usersStakes: getUpdatedUsersStakes(usersStakes, staker, vote, amount),
+  };
+};
+
+export const updateMotionStakeInDB = async (
+  { id, motionData }: MotionQuery,
+  vote: BigNumber,
+  amount: BigNumber,
+  staker: string,
+  requiredStake: Decimal,
+) => {
+  await mutate('updateColonyAction', {
+    input: {
+      id,
+      motionData: getUpdatedMotionData(
+        motionData,
+        vote,
+        amount,
+        staker,
+        requiredStake,
+      ),
+    },
+  });
+};
+
+export const getMotionSide = (vote: BigNumber) => {
+  if (vote.eq(1)) {
+    return MotionSide.YAY;
+  }
+
+  return MotionSide.NAY;
+};

--- a/src/handlers/motions/index.ts
+++ b/src/handlers/motions/index.ts
@@ -1,1 +1,2 @@
 export { default as handleMotionCreated } from './motionCreated';
+export { default as handleMotionStaked } from './motionStaked';

--- a/src/handlers/motions/motionCreated.ts
+++ b/src/handlers/motions/motionCreated.ts
@@ -1,4 +1,3 @@
-import { motionSpecificEventsListener } from '~eventListener';
 import networkClient from '~networkClient';
 import { ColonyOperations, ContractEvent } from '~types';
 import {
@@ -7,7 +6,7 @@ import {
   writeMintTokensMotionToDB,
 } from '~utils';
 
-export default async (event: ContractEvent) => {
+export default async (event: ContractEvent): Promise<void> => {
   const {
     contractAddress: colonyAddress,
     args: { motionId },
@@ -23,7 +22,7 @@ export default async (event: ContractEvent) => {
 
     const contractOperation = motionData.parsedAction.name;
 
-    /* Handle the action type-specific mutation here*/
+    /* Handle the action type-specific mutation here */
     switch (contractOperation) {
       case ColonyOperations.MintTokens: {
         await writeMintTokensMotionToDB(event, motionData);
@@ -34,8 +33,6 @@ export default async (event: ContractEvent) => {
       }
     }
     verbose(`${contractOperation} Motion Created`);
-
-    await motionSpecificEventsListener(colonyAddress);
   } catch {
     verbose('Unable to create Motion.');
   }

--- a/src/handlers/motions/motionCreated.ts
+++ b/src/handlers/motions/motionCreated.ts
@@ -2,7 +2,7 @@ import networkClient from '~networkClient';
 import { ColonyOperations, ContractEvent } from '~types';
 import {
   verbose,
-  getParsedActionFromMotion,
+  extractDataFromMotion,
   writeMintTokensMotionToDB,
 } from '~utils';
 
@@ -12,23 +12,24 @@ export default async (event: ContractEvent) => {
     args: { motionId },
   } = event;
 
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
-  const parsedAction = await getParsedActionFromMotion(motionId, colonyClient);
+  try {
+    const colonyClient = await networkClient.getColonyClient(colonyAddress);
+    const motionData = await extractDataFromMotion(motionId, colonyClient);
 
-  if (parsedAction) {
-    const contractOperation = parsedAction.name;
+    const contractOperation = motionData.parsedAction.name;
 
     /* Handle the action type-specific mutation here*/
     switch (contractOperation) {
       case ColonyOperations.MintTokens: {
-        await writeMintTokensMotionToDB(event, parsedAction);
+        await writeMintTokensMotionToDB(event, motionData);
         break;
       }
       default: {
         break;
       }
     }
-
     verbose(`${contractOperation} Motion Created`);
+  } catch {
+    verbose('Unable to create Motion.');
   }
 };

--- a/src/handlers/motions/motionCreated.ts
+++ b/src/handlers/motions/motionCreated.ts
@@ -1,3 +1,4 @@
+import { motionSpecificEventsListener } from '~eventListener';
 import networkClient from '~networkClient';
 import { ColonyOperations, ContractEvent } from '~types';
 import {
@@ -14,7 +15,11 @@ export default async (event: ContractEvent) => {
 
   try {
     const colonyClient = await networkClient.getColonyClient(colonyAddress);
-    const motionData = await extractDataFromMotion(motionId, colonyClient);
+    const motionData = await extractDataFromMotion(
+      motionId,
+      colonyClient,
+      colonyAddress,
+    );
 
     const contractOperation = motionData.parsedAction.name;
 
@@ -29,6 +34,8 @@ export default async (event: ContractEvent) => {
       }
     }
     verbose(`${contractOperation} Motion Created`);
+
+    await motionSpecificEventsListener(colonyAddress);
   } catch {
     verbose('Unable to create Motion.');
   }

--- a/src/handlers/motions/motionStaked.ts
+++ b/src/handlers/motions/motionStaked.ts
@@ -3,7 +3,7 @@ import { ContractEvent, MotionQuery } from '~types';
 import { verbose, getRequiredStake } from '~utils';
 import { getMotionSide, updateMotionStakeInDB } from './helpers';
 
-export default async (event: ContractEvent) => {
+export default async (event: ContractEvent): Promise<void> => {
   const {
     contractAddress: colonyAddress,
     args: { vote, amount, staker, motionId: rawMotionId },

--- a/src/handlers/motions/motionStaked.ts
+++ b/src/handlers/motions/motionStaked.ts
@@ -1,0 +1,40 @@
+import { query } from '~amplifyClient';
+import { ContractEvent, MotionQuery } from '~types';
+import { verbose, getRequiredStake } from '~utils';
+import { getMotionSide, updateMotionStakeInDB } from './helpers';
+
+export default async (event: ContractEvent) => {
+  const {
+    contractAddress: colonyAddress,
+    args: { vote, amount, staker, motionId: rawMotionId },
+  } = event;
+
+  const { items: motions }: { items: MotionQuery[] } = await query(
+    'getColonyMotions',
+    {
+      colonyAddress,
+    },
+  );
+
+  const stakedMotion = motions.find(
+    ({ motionData: { motionId } }) => motionId === rawMotionId.toString(),
+  );
+
+  if (stakedMotion) {
+    const { skillRep } = stakedMotion.motionData;
+    const requiredStake = await getRequiredStake(colonyAddress, skillRep);
+    await updateMotionStakeInDB(
+      stakedMotion,
+      vote,
+      amount,
+      staker,
+      requiredStake,
+    );
+
+    verbose(
+      `User: ${staker} staked motion with tx hash: ${
+        stakedMotion.id
+      } by ${amount.toString()} on side ${getMotionSide(vote)}`,
+    );
+  }
+};

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -2,7 +2,6 @@ import { Extension, getExtensionHash, getLogs } from '@colony/colony-js';
 
 import networkClient from './networkClient';
 import {
-  addMotionEventListener,
   deleteExtensionFromEvent,
   isExtensionDeprecated,
   isExtensionInitialised,
@@ -11,11 +10,12 @@ import {
   verbose,
   writeExtensionFromEvent,
   writeExtensionVersionFromEvent,
-  writeVotingReputationInitParamsToDB,
 } from './utils';
 import { SUPPORTED_EXTENSION_IDS } from './constants';
-import { extensionSpecificEventsListener } from './eventListener';
-import { ContractEventsSignatures } from './types';
+import {
+  extensionSpecificEventsListener,
+  motionSpecificEventsListener,
+} from './eventListener';
 
 export default async (): Promise<void> => {
   // @TODO: Set to the latest block processed by block-ingestor
@@ -178,7 +178,7 @@ const trackExtensionEvents = async (
 
     // Listen for motions if Voting Reputation is initialised.
     if (Extension.VotingReputation === extensionId && isInitialised) {
-      addMotionEventListener(ContractEventsSignatures.MotionCreated, colony);
+      await motionSpecificEventsListener(colony);
     }
 
     await writeExtensionFromEvent(

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -11,6 +11,7 @@ import {
   verbose,
   writeExtensionFromEvent,
   writeExtensionVersionFromEvent,
+  writeVotingReputationInitParamsToDB,
 } from './utils';
 import { SUPPORTED_EXTENSION_IDS } from './constants';
 import { extensionSpecificEventsListener } from './eventListener';

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ import {
   ColonyNetworkClient,
   TokenClient,
 } from '@colony/colony-js';
-import { LogDescription } from '@ethersproject/abi';
+import { LogDescription, TransactionDescription } from '@ethersproject/abi';
 
 /*
  * Custom contract event, since we need some log values as well
@@ -87,6 +87,7 @@ export enum ColonyActionType {
   VersionUpgrade = 'VERSION_UPGRADE',
   MintTokensMotion = 'MINT_TOKENS_MOTION',
 }
+
 /*
  * Contract calls
  */
@@ -108,8 +109,31 @@ export const motionNameMapping: { [key: string]: ColonyActionType } = {
   // emitDomainReputationReward: ColonyMotions.EmitDomainReputationRewardMotion,
 };
 
+export interface MotionData {
+  parsedAction: TransactionDescription;
+  motionData: {
+    motionState: number;
+  };
+}
+
 export type NetworkClients =
   | ColonyNetworkClient
   | TokenClient
   | AnyColonyClient
   | AnyVotingReputationClient;
+
+interface VotingReputationParams {
+  requiredStake: string;
+  minimumStake: string;
+}
+export interface CreateExtensionInput extends Record<string, any> {
+  colonyId: string;
+  hash: string;
+  version: number;
+  installedBy: string;
+  installedAt: number;
+  isDeprecated: boolean;
+  isDeleted: boolean;
+  isInitialized: boolean;
+  extensionConfig: VotingReputationParams | null;
+}

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -1,16 +1,4 @@
-interface VotingReputationParams {
-  requiredStake: string;
+export interface VotingReputationConfig {
   minimumStake: string;
-}
-
-export interface CreateExtensionInput extends Record<string, any> {
-  colonyId: string;
-  hash: string;
-  version: number;
-  installedBy: string;
-  installedAt: number;
-  isDeprecated: boolean;
-  isDeleted: boolean;
-  isInitialized: boolean;
-  extensionConfig: VotingReputationParams | null;
+  requiredStake: string;
 }

--- a/src/types/extensions.ts
+++ b/src/types/extensions.ts
@@ -1,0 +1,16 @@
+interface VotingReputationParams {
+  requiredStake: string;
+  minimumStake: string;
+}
+
+export interface CreateExtensionInput extends Record<string, any> {
+  colonyId: string;
+  hash: string;
+  version: number;
+  installedBy: string;
+  installedAt: number;
+  isDeprecated: boolean;
+  isDeleted: boolean;
+  isInitialized: boolean;
+  extensionConfig: VotingReputationParams | null;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,7 +4,7 @@ import {
   ColonyNetworkClient,
   TokenClient,
 } from '@colony/colony-js';
-import { LogDescription, TransactionDescription } from '@ethersproject/abi';
+import { LogDescription } from '@ethersproject/abi';
 
 /*
  * Custom contract event, since we need some log values as well
@@ -61,6 +61,7 @@ export enum ContractEventsSignatures {
 
   // Motions
   MotionCreated = 'MotionCreated(uint256,address,uint256)',
+  MotionStaked = 'MotionStaked(uint256,address,uint256,uint256)',
 }
 
 /*
@@ -88,52 +89,11 @@ export enum ColonyActionType {
   MintTokensMotion = 'MINT_TOKENS_MOTION',
 }
 
-/*
- * Contract calls
- */
-export enum ColonyOperations {
-  MintTokens = 'mintTokens',
-}
-
-export const motionNameMapping: { [key: string]: ColonyActionType } = {
-  [ColonyOperations.MintTokens]: ColonyActionType.MintTokensMotion,
-  // makePaymentFundedFromDomain: ColonyMotions.PaymentMotion,
-  // unlockToken: ColonyMotions.UnlockTokenMotion,
-  // addDomain: ColonyMotions.CreateDomainMotion,
-  // editDomain: ColonyMotions.EditDomainMotion,
-  // editColony: ColonyMotions.ColonyEditMotion,
-  // setUserRoles: ColonyMotions.SetUserRolesMotion,
-  // moveFundsBetweenPots: ColonyMotions.MoveFundsMotion,
-  // upgrade: ColonyMotions.VersionUpgradeMotion,
-  // emitDomainReputationPenalty: ColonyMotions.EmitDomainReputationPenaltyMotion,
-  // emitDomainReputationReward: ColonyMotions.EmitDomainReputationRewardMotion,
-};
-
-export interface MotionData {
-  parsedAction: TransactionDescription;
-  motionData: {
-    motionState: number;
-  };
-}
-
 export type NetworkClients =
   | ColonyNetworkClient
   | TokenClient
   | AnyColonyClient
   | AnyVotingReputationClient;
 
-interface VotingReputationParams {
-  requiredStake: string;
-  minimumStake: string;
-}
-export interface CreateExtensionInput extends Record<string, any> {
-  colonyId: string;
-  hash: string;
-  version: number;
-  installedBy: string;
-  installedAt: number;
-  isDeprecated: boolean;
-  isDeleted: boolean;
-  isInitialized: boolean;
-  extensionConfig: VotingReputationParams | null;
-}
+export * from './motions';
+export * from './extensions';

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -1,0 +1,65 @@
+import { TransactionDescription } from 'ethers/lib/utils';
+import { ColonyActionType } from '~types';
+
+/*
+ * Contract calls
+ */
+export enum ColonyOperations {
+  MintTokens = 'mintTokens',
+}
+
+export interface AugmentedMotionData {
+  parsedAction: TransactionDescription;
+  motionData: MotionData;
+}
+
+export const motionNameMapping: { [key: string]: ColonyActionType } = {
+  [ColonyOperations.MintTokens]: ColonyActionType.MintTokensMotion,
+  // makePaymentFundedFromDomain: ColonyMotions.PaymentMotion,
+  // unlockToken: ColonyMotions.UnlockTokenMotion,
+  // addDomain: ColonyMotions.CreateDomainMotion,
+  // editDomain: ColonyMotions.EditDomainMotion,
+  // editColony: ColonyMotions.ColonyEditMotion,
+  // setUserRoles: ColonyMotions.SetUserRolesMotion,
+  // moveFundsBetweenPots: ColonyMotions.MoveFundsMotion,
+  // upgrade: ColonyMotions.VersionUpgradeMotion,
+  // emitDomainReputationPenalty: ColonyMotions.EmitDomainReputationPenaltyMotion,
+  // emitDomainReputationReward: ColonyMotions.EmitDomainReputationRewardMotion,
+};
+
+export type MotionQuery = {
+  id: string;
+  motionData: MotionData;
+};
+
+export enum MotionSide {
+  YAY = 'yay',
+  NAY = 'nay',
+}
+
+interface MotionStakeFragment {
+  [MotionSide.YAY]: string;
+  [MotionSide.NAY]: string;
+}
+
+interface MotionStakes {
+  raw: MotionStakeFragment;
+  percentage: MotionStakeFragment;
+}
+
+export interface UserStake {
+  address: string;
+  stakes: {
+    raw: MotionStakeFragment;
+  };
+}
+
+export interface MotionData {
+  rootHash: string;
+  motionStakes: MotionStakes;
+  usersStakes: UserStake[];
+  motionState: number;
+  motionDomainId: string;
+  skillRep: string;
+  motionId: string;
+}

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -27,22 +27,22 @@ export const motionNameMapping: { [key: string]: ColonyActionType } = {
   // emitDomainReputationReward: ColonyMotions.EmitDomainReputationRewardMotion,
 };
 
-export type MotionQuery = {
+export interface MotionQuery {
   id: string;
   motionData: MotionData;
-};
+}
 
 export enum MotionSide {
   YAY = 'yay',
   NAY = 'nay',
 }
 
-interface MotionStakeFragment {
+export interface MotionStakeFragment {
   [MotionSide.YAY]: string;
   [MotionSide.NAY]: string;
 }
 
-interface MotionStakes {
+export interface MotionStakes {
   raw: MotionStakeFragment;
   percentage: MotionStakeFragment;
 }

--- a/src/utils/clients.ts
+++ b/src/utils/clients.ts
@@ -1,0 +1,7 @@
+import { Extension } from '@colony/colony-js';
+import networkClient from '~networkClient';
+
+export const getVotingClient = async (colonyAddress: string) => {
+  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  return await colonyClient.getExtensionClient(Extension.VotingReputation);
+};

--- a/src/utils/clients.ts
+++ b/src/utils/clients.ts
@@ -1,7 +1,9 @@
-import { Extension } from '@colony/colony-js';
+import { AnyVotingReputationClient, Extension } from '@colony/colony-js';
 import networkClient from '~networkClient';
 
-export const getVotingClient = async (colonyAddress: string) => {
+export const getVotingClient = async (
+  colonyAddress: string,
+): Promise<AnyVotingReputationClient> => {
   const colonyClient = await networkClient.getColonyClient(colonyAddress);
   return await colonyClient.getExtensionClient(Extension.VotingReputation);
 };

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -1,4 +1,4 @@
 export const getDomainDatabaseId = (
   colonyAddress: string,
-  nativeId: number,
+  nativeId: number | string,
 ): string => `${colonyAddress}_${nativeId}`;

--- a/src/utils/events/eventListeners/eventListenerGenerator.ts
+++ b/src/utils/events/eventListeners/eventListenerGenerator.ts
@@ -19,7 +19,7 @@ export const eventListenerGenerator = async (
   contractAddress: string,
   clientType: ClientType = ClientType.NetworkClient,
 ): Promise<void> => {
-  let { client, provider } = await getClientAndProvider(
+  const { client, provider } = await getClientAndProvider(
     clientType,
     contractAddress,
   );
@@ -43,7 +43,7 @@ export const eventListenerGenerator = async (
 const getClientAndProvider = async (
   clientType: ClientType,
   contractAddress: string,
-) => {
+): Promise<{ client: NetworkClients; provider: Provider }> => {
   let client: NetworkClients = networkClient;
   let { provider } = client;
 
@@ -76,7 +76,7 @@ const getEventFilter = (
   eventSignature: string,
   contractAddress: string,
   clientType: ClientType,
-) => {
+): { topics: Array<string | null>; address?: string } => {
   const filter: { topics: Array<string | null>; address?: string } = {
     topics: [utils.id(eventSignature)],
   };
@@ -113,7 +113,7 @@ const addEventToQueue = async (
   contractAddress: string,
   log: Log,
   provider: Provider,
-) => {
+): Promise<void> => {
   const {
     transactionHash,
     logIndex,
@@ -123,7 +123,7 @@ const addEventToQueue = async (
   try {
     const { hash: blockHash, timestamp } = await provider.getBlock(blockNumber);
 
-    let event = {
+    const event = {
       blockNumber,
       transactionHash,
       logIndex,

--- a/src/utils/events/eventListeners/eventListeners.ts
+++ b/src/utils/events/eventListeners/eventListeners.ts
@@ -7,7 +7,10 @@ import { addEvent } from '~eventQueue';
 import networkClient from '~networkClient';
 import { ContractEventsSignatures } from '~types';
 
-import { eventListenerGenerator } from './eventListenerGenerator';
+import {
+  eventListenerGenerator,
+  RemoveListener,
+} from './eventListenerGenerator';
 
 /**
  * Network Client specific event listener,
@@ -16,12 +19,13 @@ import { eventListenerGenerator } from './eventListenerGenerator';
 export const addNetworkEventListener = async (
   eventSignature: ContractEventsSignatures,
   contractAddress: string = networkClient.address,
-): Promise<void> =>
+): Promise<void> => {
   await eventListenerGenerator(
     eventSignature,
     contractAddress,
     ClientType.NetworkClient,
   );
+};
 
 /**
  * Colony Client specific event listener,
@@ -30,12 +34,13 @@ export const addNetworkEventListener = async (
 export const addColonyEventListener = async (
   eventSignature: ContractEventsSignatures,
   contractAddress: string,
-): Promise<void> =>
+): Promise<void> => {
   await eventListenerGenerator(
     eventSignature,
     contractAddress,
     ClientType.ColonyClient,
   );
+};
 
 /**
  * Token Client specific event listener,
@@ -44,12 +49,13 @@ export const addColonyEventListener = async (
 export const addTokenEventListener = async (
   eventSignature: ContractEventsSignatures,
   contractAddress: string,
-): Promise<void> =>
+): Promise<void> => {
   await eventListenerGenerator(
     eventSignature,
     contractAddress,
     ClientType.TokenClient,
   );
+};
 
 /**
  * Voting Reputation Client specific event listener,
@@ -58,12 +64,15 @@ export const addTokenEventListener = async (
 export const addMotionEventListener = async (
   eventSignature: ContractEventsSignatures,
   colonyAddress: string,
-): Promise<void> =>
-  await eventListenerGenerator(
+): Promise<RemoveListener> => {
+  const removeListener = await eventListenerGenerator(
     eventSignature,
     colonyAddress,
     ClientType.VotingReputationClient,
   );
+
+  return removeListener;
+};
 
 /**
  * Extension specific event listener

--- a/src/utils/events/eventListeners/eventListeners.ts
+++ b/src/utils/events/eventListeners/eventListeners.ts
@@ -58,7 +58,7 @@ export const addTokenEventListener = async (
 export const addMotionEventListener = async (
   eventSignature: ContractEventsSignatures,
   colonyAddress: string,
-) =>
+): Promise<void> =>
   await eventListenerGenerator(
     eventSignature,
     colonyAddress,

--- a/src/utils/events/eventListeners/index.ts
+++ b/src/utils/events/eventListeners/index.ts
@@ -1,1 +1,2 @@
 export * from './eventListeners';
+export * from './eventListenerGenerator';

--- a/src/utils/extensions/writeExtension.ts
+++ b/src/utils/extensions/writeExtension.ts
@@ -4,7 +4,7 @@ import { Extension, getExtensionHash, getLogs } from '@colony/colony-js';
 
 import networkClient from '~networkClient';
 import { mutate } from '~amplifyClient';
-import { ContractEvent, CreateExtensionInput } from '~types';
+import { ContractEvent, VotingReputationConfig } from '~types';
 import { verbose, toNumber } from '~utils';
 
 import { getExtensionContract } from './contracts';
@@ -64,7 +64,7 @@ export const writeExtensionFromEvent = async (
     colony,
   );
 
-  const input: CreateExtensionInput = {
+  const input: Record<string, any> = {
     colonyId: colony,
     hash: extensionHash,
     version: overrideVersion ?? convertedVersion,
@@ -179,7 +179,7 @@ export const isExtensionInitialised = async (
 const getExtensionConfig = async (
   extensionId: Extension,
   colonyAddress: string,
-) => {
+): Promise<VotingReputationConfig | null> => {
   switch (extensionId) {
     case Extension.VotingReputation: {
       const colonyClient = await networkClient.getColonyClient(colonyAddress);
@@ -207,7 +207,7 @@ const getExtensionConfig = async (
 export const writeVotingReputationInitParamsToDB = async (
   extensionAddress: string,
   colonyAddress: string,
-) => {
+): Promise<void> => {
   const extensionConfig = await getExtensionConfig(
     Extension.VotingReputation,
     colonyAddress,

--- a/src/utils/extensions/writeExtension.ts
+++ b/src/utils/extensions/writeExtension.ts
@@ -203,6 +203,7 @@ const getExtensionConfig = async (
     }
   }
 };
+
 export const writeVotingReputationInitParamsToDB = async (
   extensionAddress: string,
   colonyAddress: string,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './tokens';
 export * from './actions';
 export * from './domains';
 export * from './motions';
+export * from './events';

--- a/src/utils/motions.ts
+++ b/src/utils/motions.ts
@@ -3,7 +3,12 @@ import { BigNumber } from 'ethers';
 import Decimal from 'decimal.js';
 
 import { mutate } from '~amplifyClient';
-import { ContractEvent, AugmentedMotionData, motionNameMapping } from '~types';
+import {
+  ContractEvent,
+  AugmentedMotionData,
+  motionNameMapping,
+  MotionStakeFragment,
+} from '~types';
 
 import { getColonyTokenAddress } from './tokens';
 import { getVotingClient } from './clients';
@@ -12,13 +17,13 @@ import { getDomainDatabaseId } from './domains';
 export const convertStakeToPercentage = (
   stake: string | Decimal,
   requiredStake: Decimal,
-) => new Decimal(stake).div(requiredStake).mul(100).toDP(2).toString();
+): string => new Decimal(stake).div(requiredStake).mul(100).toDP(2).toString();
 
 export const getMotionStakePercentages = (
   yay: BigNumber,
   nay: BigNumber,
   requiredStake: Decimal,
-) => ({
+): MotionStakeFragment => ({
   yay: convertStakeToPercentage(yay.toString(), requiredStake),
   nay: convertStakeToPercentage(nay.toString(), requiredStake),
 });
@@ -26,7 +31,7 @@ export const getMotionStakePercentages = (
 export const getRequiredStake = async (
   colonyAddress: string,
   skillRep: string,
-) => {
+): Promise<Decimal> => {
   const votingReputationClient = await getVotingClient(colonyAddress);
   const totalStakeFraction =
     await votingReputationClient.getTotalStakeFraction();
@@ -40,7 +45,7 @@ export const extractDataFromMotion = async (
   motionId: BigNumber,
   colonyClient: AnyColonyClient,
   colonyAddress: string,
-) => {
+): Promise<AugmentedMotionData> => {
   const votingClient = await colonyClient.getExtensionClient(
     Extension.VotingReputation,
   );
@@ -93,7 +98,7 @@ export const writeMintTokensMotionToDB = async (
     args: { creator, domainId },
   }: ContractEvent,
   { parsedAction, motionData }: AugmentedMotionData,
-) => {
+): Promise<void> => {
   const { name, args: actionArgs } = parsedAction;
   const amount = actionArgs[0].toString();
   const tokenAddress = await getColonyTokenAddress(colonyAddress);


### PR DESCRIPTION
Adds support for motion staking.

I recommend testing with this branch in the CDapp: https://github.com/JoinColony/colonyCDapp/pull/310.

Should listen for MotionStaked events whenever it detects the VotingReputation extn is initialised and populate them to the db for use in the client. 
