### PR TITLE
Fix Payment action being picked up as Move Funds 

### DIFF
--- a/src/handlers/actions/moveFunds.ts
+++ b/src/handlers/actions/moveFunds.ts
@@ -5,10 +5,21 @@ import {
   ColonyClientV3,
   ColonyClientV4,
 } from '@colony/colony-js';
-import { BigNumber } from 'ethers';
-import networkClient from '~/networkClient';
-import { ColonyActionType, ContractEvent } from '~/types';
-import { toNumber, writeActionFromEvent, getDomainDatabaseId } from '~/utils';
+import { BigNumber, utils } from 'ethers';
+
+import networkClient from '~networkClient';
+import {
+  ColonyActionType,
+  ContractEvent,
+  ContractEventsSignatures,
+} from '~types';
+import {
+  toNumber,
+  writeActionFromEvent,
+  getDomainDatabaseId,
+  verbose,
+} from '~utils';
+import provider from '~provider';
 
 /**
  * The handler makes use of colonyClient getDomainFromFundingPot method which is only
@@ -25,6 +36,19 @@ const isSupportedColonyClient = (
   (colonyClient as SupportedColonyClient).getDomainFromFundingPot !== undefined;
 
 export default async (event: ContractEvent): Promise<void> => {
+  const receipt = await provider.getTransactionReceipt(event.transactionHash);
+  const hasPaymentAddedEvent = receipt.logs.some((log) =>
+    log.topics.includes(utils.id(ContractEventsSignatures.PaymentAdded)),
+  );
+  console.log('has payment added: ', hasPaymentAddedEvent);
+
+  if (hasPaymentAddedEvent) {
+    verbose(
+      'Not acting upon the ColonyFundsMovedBetweenFundingPots event as a PaymentAdded event was present in the same transaction',
+    );
+    return;
+  }
+
   const { contractAddress: colonyAddress } = event;
   const {
     agent: initiatorAddress,


### PR DESCRIPTION
This was due to the `ColonyFundsMovedBetweenFundingPots` event being present in both actions. I now added a check to Move Funds handler to determine if it really is that event.

## Testing
Running block-ingestor on this branch separately (you can find the patch you need to apply to the CDapp repo in https://github.com/JoinColony/block-ingestor/pull/23), create a colony using the wizard and test the payment action. It should show as Payment action instead of Move Funds.

Resolves https://github.com/JoinColony/colonyCDapp/issues/315