### PR TITLE
Add motion reward claimed support

### DIFF
--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -45,6 +45,10 @@ export const motionSpecificEventsListener = async (
     ContractEventsSignatures.MotionFinalized,
     colonyAddress,
   );
+  await addMotionEventListener(
+    ContractEventsSignatures.MotionRewardClaimed,
+    colonyAddress,
+  );
 };
 
 export const extensionSpecificEventsListener = async (

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -23,6 +23,7 @@ import {
   handleMotionCreated,
   handleMotionStaked,
   handleMotionFinalized,
+  handleMotionRewardClaimed,
 } from './handlers';
 
 dotenv.config();
@@ -122,6 +123,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.MotionFinalized: {
       await handleMotionFinalized(event);
+      return;
+    }
+
+    case ContractEventsSignatures.MotionRewardClaimed: {
+      await handleMotionRewardClaimed(event);
       return;
     }
 

--- a/src/handlers/motions/index.ts
+++ b/src/handlers/motions/index.ts
@@ -1,3 +1,4 @@
 export { default as handleMotionCreated } from './motionCreated';
 export { default as handleMotionStaked } from './motionStaked';
 export { default as handleMotionFinalized } from './motionFinalized';
+export { default as handleMotionRewardClaimed } from './motionRewardClaimed';

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -46,5 +46,6 @@ export const getStakerReward = async (
       nay: stakingRewardNay.toString(),
       yay: stakingRewardYay.toString(),
     },
+    isClaimed: false,
   };
 };

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -1,0 +1,43 @@
+import { ContractEvent, MotionData } from '~types';
+import { getMotionFromDB, updateMotionInDB } from './helpers';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const {
+    contractAddress: colonyAddress,
+    args: { motionId, staker },
+  } = event;
+
+  const claimedMotion = await getMotionFromDB(colonyAddress, motionId);
+
+  if (claimedMotion) {
+    const {
+      motionData: { stakerRewards },
+    } = claimedMotion;
+
+    const updatedStakerRewards = stakerRewards.map((stakerReward) => {
+      const { address } = stakerReward;
+
+      if (address !== staker) {
+        return stakerReward;
+      }
+
+      return {
+        ...stakerReward,
+        /*
+         * This is safe because, from the front end,
+         * we claim both sides (if there were rewards on both sides)
+         * at the same time. Simply adding a flag lets us preserve the original values,
+         * which is useful for displaying winnings in the Claim Widget.
+         */
+        isClaimed: true,
+      };
+    });
+
+    const updatedMotionData: MotionData = {
+      ...claimedMotion.motionData,
+      stakerRewards: updatedStakerRewards,
+    };
+
+    await updateMotionInDB(claimedMotion.id, updatedMotionData);
+  }
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,7 @@ export enum ContractEventsSignatures {
   MotionCreated = 'MotionCreated(uint256,address,uint256)',
   MotionStaked = 'MotionStaked(uint256,address,uint256,uint256)',
   MotionFinalized = 'MotionFinalized(uint256,bytes,bool)',
+  MotionRewardClaimed = 'MotionRewardClaimed(uint256,address,uint256,uint256)',
 }
 
 /*

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -63,6 +63,7 @@ export interface UserStakes {
 export interface StakerReward {
   address: string;
   rewards: MotionStakeFragment;
+  isClaimed: boolean;
 }
 
 export interface MotionQuery {


### PR DESCRIPTION
This PR adds block ingestor support for motion reward claimed events. Test with this branch: https://github.com/JoinColony/colonyCDapp/pull/324/ 

(note that in the cdapp branch, we actually point to https://github.com/JoinColony/block-ingestor/pull/42, which is based off this branch. This in intentional)