### PR TITLE
Add db mutations for motion staking

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -183,6 +183,14 @@ export const queries = {
             userMinStake
             rootHash
             motionDomainId
+            stakerRewards {
+              address
+              rewards {
+                yay
+                nay
+              }
+            }
+            isFinalized
           }
           createdAt
         }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -184,6 +184,7 @@ export const queries = {
             rootHash
             motionDomainId
           }
+          createdAt
         }
       }
     }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -155,6 +155,7 @@ export const queries = {
           id
           motionData {
             motionId
+            nativeMotionId
             motionStakes {
               raw {
                 nay
@@ -189,10 +190,11 @@ export const queries = {
                 yay
                 nay
               }
+              isClaimed
             }
             isFinalized
+            createdBy
           }
-          createdAt
         }
       }
     }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -207,20 +207,20 @@ export default (): void => {
   });
 };
 
-export const query = async (
+export const query = async <T = any>(
   queryName: keyof typeof queries,
   /*
    * @TODO Would be nice if at some point we could actually set these
    * types properly
    */
   variables?: Record<string, unknown>,
-): Promise<any> => {
+): Promise<T | undefined> => {
   try {
     const result = await API.graphql(
       graphqlOperation(queries[queryName], variables),
     );
     const [internalQueryName] = Object.keys(result?.data ?? []);
-    return result?.data[internalQueryName] ?? {};
+    return result?.data[internalQueryName];
   } catch (error) {
     console.error(`Could not fetch query "${queryName}"`, error);
     return undefined;

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -145,6 +145,49 @@ export const queries = {
       }
     }
   `,
+  getColonyMotions: /* GraphQL */ `
+    query GetActionsByColony($colonyAddress: ID!) {
+      getActionsByColony(
+        colonyId: $colonyAddress
+        filter: { isMotion: { eq: true } }
+      ) {
+        items {
+          id
+          motionData {
+            motionId
+            motionStakes {
+              raw {
+                nay
+                yay
+              }
+              percentage {
+                nay
+                yay
+              }
+            }
+            requiredStake
+            remainingStakes
+            usersStakes {
+              address
+              stakes {
+                raw {
+                  yay
+                  nay
+                }
+                percentage {
+                  yay
+                  nay
+                }
+              }
+            }
+            userMinStake
+            rootHash
+            motionDomainId
+          }
+        }
+      }
+    }
+  `,
 };
 
 export default (): void => {

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -41,6 +41,10 @@ export const motionSpecificEventsListener = async (
     ContractEventsSignatures.MotionStaked,
     colonyAddress,
   );
+  await addMotionEventListener(
+    ContractEventsSignatures.MotionFinalized,
+    colonyAddress,
+  );
 };
 
 export const extensionSpecificEventsListener = async (

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -45,6 +45,10 @@ export const motionSpecificEventsListener = async (
     ContractEventsSignatures.MotionFinalized,
     colonyAddress,
   );
+  await addMotionEventListener(
+    ContractEventsSignatures.MotionRewardClaimed,
+    colonyAddress,
+  );
 };
 
 export const extensionSpecificEventsListener = async (

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -23,6 +23,7 @@ import {
   handleMotionCreated,
   handleMotionStaked,
   handleMotionFinalized,
+  handleMotionRewardClaimed,
 } from './handlers';
 
 dotenv.config();
@@ -122,6 +123,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.MotionFinalized: {
       await handleMotionFinalized(event);
+      return;
+    }
+
+    case ContractEventsSignatures.MotionRewardClaimed: {
+      await handleMotionRewardClaimed(event);
       return;
     }
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -22,6 +22,7 @@ import {
   handleVersionUpgradeAction,
   handleMotionCreated,
   handleMotionStaked,
+  handleMotionFinalized,
 } from './handlers';
 
 dotenv.config();
@@ -116,6 +117,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.MotionStaked: {
       await handleMotionStaked(event);
+      return;
+    }
+
+    case ContractEventsSignatures.MotionFinalized: {
+      await handleMotionFinalized(event);
       return;
     }
 

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -1,5 +1,7 @@
 import { BigNumber } from 'ethers';
 import { MotionSide } from '~types';
 
+export * from './motionStaked/helpers';
+
 export const getMotionSide = (vote: BigNumber): MotionSide =>
   vote.eq(1) ? MotionSide.YAY : MotionSide.NAY;

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -20,12 +20,11 @@ export const updateMotionInDB = async (
   });
 };
 
-/*
- * Motion ids are not unique between voting reputation installations. If you had a motion with id of 1
- * in a previous voting reputation installation, you will get another one after uninstalling and reinstalling
- * the voting reputation client. So, we only want the one created most recently, since that's the one created
- * by the currently installed version of the voting reputation extension.
- */
+export const getMotionDatabaseId = (
+  chainId: number,
+  votingRepExtnAddress: string,
+  nativeMotionId: BigNumber,
+): string => `${chainId}-${votingRepExtnAddress}_${nativeMotionId}`;
 
 export const getMotionFromDB = async (
   colonyAddress: string,

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -29,7 +29,7 @@ export const updateMotionInDB = async (
 
 export const getMotionFromDB = async (
   colonyAddress: string,
-  motionId: BigNumber,
+  databaseMotionId: string,
 ): Promise<MotionQuery | undefined> => {
   const { items: motions } =
     (await query<{ items: MotionQuery[] }>('getColonyMotions', {
@@ -44,18 +44,9 @@ export const getMotionFromDB = async (
     return undefined;
   }
 
-  const motionsWithCorrectId = motions.filter(
-    ({ motionData: { motionId: id } }) => id === motionId.toString(),
+  const motion = motions.find(
+    ({ motionData: { motionId } }) => motionId === databaseMotionId,
   );
-
-  if (motionsWithCorrectId.length > 1) {
-    motionsWithCorrectId.sort(
-      (a, b) =>
-        new Date(a.createdAt).valueOf() - new Date(b.createdAt).valueOf(),
-    );
-  }
-
-  const motion = motionsWithCorrectId.pop();
 
   if (!motion) {
     verbose(

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -1,7 +1,20 @@
 import { BigNumber } from 'ethers';
-import { MotionSide } from '~types';
+import { mutate } from '~amplifyClient';
+import { MotionData, MotionSide } from '~types';
 
 export * from './motionStaked/helpers';
 
 export const getMotionSide = (vote: BigNumber): MotionSide =>
   vote.eq(1) ? MotionSide.YAY : MotionSide.NAY;
+
+export const updateMotionInDB = async (
+  id: string,
+  motionData: MotionData,
+): Promise<void> => {
+  await mutate('updateColonyAction', {
+    input: {
+      id,
+      motionData,
+    },
+  });
+};

--- a/src/handlers/motions/index.ts
+++ b/src/handlers/motions/index.ts
@@ -1,3 +1,4 @@
 export { default as handleMotionCreated } from './motionCreated';
 export { default as handleMotionStaked } from './motionStaked';
 export { default as handleMotionFinalized } from './motionFinalized';
+export { default as handleMotionRewardClaimed } from './motionRewardClaimed';

--- a/src/handlers/motions/index.ts
+++ b/src/handlers/motions/index.ts
@@ -1,2 +1,3 @@
 export { default as handleMotionCreated } from './motionCreated';
 export { default as handleMotionStaked } from './motionStaked';
+export { default as handleMotionFinalized } from './motionFinalized/motionFinalized';

--- a/src/handlers/motions/index.ts
+++ b/src/handlers/motions/index.ts
@@ -1,3 +1,3 @@
 export { default as handleMotionCreated } from './motionCreated';
 export { default as handleMotionStaked } from './motionStaked';
-export { default as handleMotionFinalized } from './motionFinalized/motionFinalized';
+export { default as handleMotionFinalized } from './motionFinalized';

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -1,15 +1,17 @@
 import { AnyColonyClient, Extension } from '@colony/colony-js';
-import { TransactionDescription } from 'ethers/lib/utils';
 import { BigNumber } from 'ethers';
+import { TransactionDescription } from 'ethers/lib/utils';
 
-import { mutate } from '../amplifyClient';
-import { ContractEvent, motionNameMapping, MotionData } from '../types';
-import { getRequiredStake, getUserMinStake } from '~handlers/motions/helpers';
+import { mutate } from '~amplifyClient';
+import { MotionData, ContractEvent, motionNameMapping } from '~types';
+import {
+  getColonyTokenAddress,
+  getDomainDatabaseId,
+  getVotingClient,
+  verbose,
+} from '~utils';
 
-import { getVotingClient } from './clients';
-import { getDomainDatabaseId } from './domains';
-import { verbose } from './logger';
-import { getColonyTokenAddress } from './tokens';
+import { getRequiredStake, getUserMinStake } from '../helpers';
 
 export const getParsedActionFromMotion = async (
   motionId: string,

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -16,6 +16,7 @@ import {
   getRequiredStake,
   getUserMinStake,
 } from '../helpers';
+
 export const getParsedActionFromMotion = async (
   motionId: string,
   colonyClient: AnyColonyClient,

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -11,7 +11,11 @@ import {
   verbose,
 } from '~utils';
 
-import { getRequiredStake, getUserMinStake } from '../helpers';
+import {
+  getMotionDatabaseId,
+  getRequiredStake,
+  getUserMinStake,
+} from '../helpers';
 export const getParsedActionFromMotion = async (
   motionId: string,
   colonyClient: AnyColonyClient,
@@ -31,12 +35,6 @@ export const getParsedActionFromMotion = async (
     return undefined;
   }
 };
-
-export const getMotionDatabaseId = (
-  chainId: number,
-  votingRepExtnAddress: string,
-  nativeMotionId: BigNumber,
-): string => `${chainId}-${votingRepExtnAddress}_${nativeMotionId}`;
 
 const getMotionData = async (
   colonyAddress: string,

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -12,7 +12,6 @@ import {
 } from '~utils';
 
 import { getRequiredStake, getUserMinStake } from '../helpers';
-
 export const getParsedActionFromMotion = async (
   motionId: string,
   colonyClient: AnyColonyClient,
@@ -32,6 +31,12 @@ export const getParsedActionFromMotion = async (
     return undefined;
   }
 };
+
+export const getMotionDatabaseId = (
+  chainId: number,
+  votingRepExtnAddress: string,
+  nativeMotionId: BigNumber,
+): string => `${chainId}-${votingRepExtnAddress}_${nativeMotionId}`;
 
 const getMotionData = async (
   colonyAddress: string,
@@ -53,8 +58,12 @@ const getMotionData = async (
     skillRep,
   );
 
+  const { chainId } = await votingClient.provider.getNetwork();
+
   return {
-    motionId: motionId.toString(),
+    createdBy: votingClient.address,
+    motionId: getMotionDatabaseId(chainId, votingClient.address, motionId),
+    nativeMotionId: motionId.toString(),
     motionStakes: {
       raw: {
         nay: '0',

--- a/src/handlers/motions/motionCreated/index.ts
+++ b/src/handlers/motions/motionCreated/index.ts
@@ -1,0 +1,1 @@
+export { default } from './motionCreated';

--- a/src/handlers/motions/motionCreated/motionCreated.ts
+++ b/src/handlers/motions/motionCreated/motionCreated.ts
@@ -1,10 +1,10 @@
 import networkClient from '~networkClient';
 import { ColonyOperations, ContractEvent } from '~types';
+import { verbose } from '~utils';
 import {
   getParsedActionFromMotion,
-  verbose,
   writeMintTokensMotionToDB,
-} from '~utils';
+} from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -46,5 +46,6 @@ export const getStakerReward = async (
       nay: stakingRewardNay.toString(),
       yay: stakingRewardYay.toString(),
     },
+    isClaimed: false,
   };
 };

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'ethers';
 
-import { StakerReward } from '~types';
+import { MotionVote, StakerReward } from '~types';
 import { getVotingClient } from '~utils';
 
 export const getStakerReward = async (
@@ -25,7 +25,7 @@ export const getStakerReward = async (
     [stakingRewardYay] = await votingReputationClient.getStakerReward(
       motionId,
       userAddress,
-      1,
+      MotionVote.YAY,
     );
   } catch (error) {
     // We don't care to catch the error since we fallback to it's initial value
@@ -34,7 +34,7 @@ export const getStakerReward = async (
     [stakingRewardNay] = await votingReputationClient.getStakerReward(
       motionId,
       userAddress,
-      0,
+      MotionVote.NAY,
     );
   } catch (error) {
     // silent error

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -1,0 +1,50 @@
+import { BigNumber } from 'ethers';
+
+import { StakerReward } from '~types';
+import { getVotingClient } from '~utils';
+
+export const getStakerReward = async (
+  motionId: string,
+  userAddress: string,
+  colonyAddress: string,
+): Promise<StakerReward> => {
+  const votingReputationClient = await getVotingClient(colonyAddress);
+
+  /*
+   * If **anyone** staked on a side, calling the rewards function returns 0 if there's no reward (even for
+   * a user who didnd't stake).
+   *
+   * But calling the rewards function on a side where **no one** has voted
+   * will result in an error being thrown.
+   *
+   * Hence the try/catch.
+   */
+  let stakingRewardYay = BigNumber.from(0);
+  let stakingRewardNay = BigNumber.from(0);
+  try {
+    [stakingRewardYay] = await votingReputationClient.getStakerReward(
+      motionId,
+      userAddress,
+      1,
+    );
+  } catch (error) {
+    // We don't care to catch the error since we fallback to it's initial value
+  }
+  try {
+    [stakingRewardNay] = await votingReputationClient.getStakerReward(
+      motionId,
+      userAddress,
+      0,
+    );
+  } catch (error) {
+    // silent error
+  }
+
+  return {
+    address: userAddress,
+    rewards: {
+      nay: stakingRewardNay.toString(),
+      yay: stakingRewardYay.toString(),
+    },
+  };
+};

--- a/src/handlers/motions/motionFinalized/index.ts
+++ b/src/handlers/motions/motionFinalized/index.ts
@@ -1,0 +1,1 @@
+export { default } from './motionFinalized';

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,6 +1,10 @@
 import { ContractEvent } from '~types';
-import { getMotionDatabaseId, getVotingClient } from '~utils';
-import { getMotionFromDB, updateMotionInDB } from '../helpers';
+import { getVotingClient } from '~utils';
+import {
+  getMotionDatabaseId,
+  getMotionFromDB,
+  updateMotionInDB,
+} from '../helpers';
 import { getStakerReward } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,4 +1,5 @@
 import { ContractEvent } from '~types';
+import { getMotionDatabaseId, getVotingClient } from '~utils';
 import { getMotionFromDB, updateMotionInDB } from '../helpers';
 import { getStakerReward } from './helpers';
 
@@ -8,7 +9,17 @@ export default async (event: ContractEvent): Promise<void> => {
     args: { motionId },
   } = event;
 
-  const finalizedMotion = await getMotionFromDB(colonyAddress, motionId);
+  const votingClient = await getVotingClient(colonyAddress);
+  const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
+  const finalizedMotion = await getMotionFromDB(
+    colonyAddress,
+    motionDatabaseId,
+  );
   if (finalizedMotion) {
     const {
       motionData: { usersStakes },

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,0 +1,33 @@
+import { ContractEvent } from '~types';
+import { getMotionFromDB, updateMotionInDB } from '../helpers';
+import { getStakerReward } from './helpers';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const {
+    contractAddress: colonyAddress,
+    args: { motionId },
+  } = event;
+
+  const finalizedMotion = await getMotionFromDB(colonyAddress, motionId);
+  if (finalizedMotion) {
+    const {
+      motionData: { usersStakes },
+      motionData,
+    } = finalizedMotion;
+
+    const updatedStakerRewards = await Promise.all(
+      usersStakes.map(
+        async ({ address: userAddress }) =>
+          await getStakerReward(motionId, userAddress, colonyAddress),
+      ),
+    );
+
+    const updatedMotionData = {
+      ...motionData,
+      stakerRewards: updatedStakerRewards,
+      isFinalized: true,
+    };
+
+    await updateMotionInDB(finalizedMotion.id, updatedMotionData);
+  }
+};

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -1,6 +1,10 @@
 import { ContractEvent, MotionData } from '~types';
-import { getMotionDatabaseId, getVotingClient } from '~utils';
-import { getMotionFromDB, updateMotionInDB } from './helpers';
+import { getVotingClient } from '~utils';
+import {
+  getMotionDatabaseId,
+  getMotionFromDB,
+  updateMotionInDB,
+} from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -1,4 +1,5 @@
 import { ContractEvent, MotionData } from '~types';
+import { getMotionDatabaseId, getVotingClient } from '~utils';
 import { getMotionFromDB, updateMotionInDB } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
@@ -7,7 +8,14 @@ export default async (event: ContractEvent): Promise<void> => {
     args: { motionId, staker },
   } = event;
 
-  const claimedMotion = await getMotionFromDB(colonyAddress, motionId);
+  const votingClient = await getVotingClient(colonyAddress);
+  const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
+  const claimedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
 
   if (claimedMotion) {
     const {

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -1,0 +1,43 @@
+import { ContractEvent, MotionData } from '~types';
+import { getMotionFromDB, updateMotionInDB } from './helpers';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const {
+    contractAddress: colonyAddress,
+    args: { motionId, staker },
+  } = event;
+
+  const claimedMotion = await getMotionFromDB(colonyAddress, motionId);
+
+  if (claimedMotion) {
+    const {
+      motionData: { stakerRewards },
+    } = claimedMotion;
+
+    const updatedStakerRewards = stakerRewards.map((stakerReward) => {
+      const { address } = stakerReward;
+
+      if (address !== staker) {
+        return stakerReward;
+      }
+
+      return {
+        ...stakerReward,
+        /*
+         * This is safe because, from the front end,
+         * we claim both sides (if there were rewards on both sides)
+         * at the same time. Simply adding a flag lets us preserve the original values,
+         * which is useful for displaying winnings in the Claim Widget.
+         */
+        isClaimed: true,
+      };
+    });
+
+    const updatedMotionData: MotionData = {
+      ...claimedMotion.motionData,
+      stakerRewards: updatedStakerRewards,
+    };
+
+    await updateMotionInDB(claimedMotion.id, updatedMotionData);
+  }
+};

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -1,7 +1,34 @@
 import { BigNumber } from 'ethers';
+import { MotionStakes } from '~types';
 
 export const getRequiredStake = (
   skillRep: BigNumber,
   totalStakeFraction: BigNumber,
 ): BigNumber =>
   skillRep.mul(totalStakeFraction).div(BigNumber.from(10).pow(18));
+
+export const getMotionStakes = (
+  requiredStake: BigNumber,
+  [totalNayStakesRaw, totalYayStakesRaw]: [BigNumber, BigNumber],
+): MotionStakes => {
+  const totalYayStakesPercentage = BigNumber.from(totalYayStakesRaw)
+    .div(requiredStake)
+    .mul(100);
+
+  const totalNayStakesPercentage = BigNumber.from(totalNayStakesRaw)
+    .div(requiredStake)
+    .mul(100);
+
+  const motionStakes: MotionStakes = {
+    raw: {
+      yay: totalYayStakesRaw.toString(),
+      nay: totalNayStakesRaw.toString(),
+    },
+    percentage: {
+      yay: totalYayStakesPercentage.toString(),
+      nay: totalNayStakesPercentage.toString(),
+    },
+  };
+
+  return motionStakes;
+};

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -157,7 +157,7 @@ export const getUpdatedUsersStakes = (
   return [...usersStakes, newUserStakes];
 };
 
-const getUserMinStake = (
+export const getUserMinStake = (
   totalStakeFraction: BigNumber,
   userMinStakeFraction: BigNumber,
   skillRep: BigNumber,

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers';
-import { MotionStakes } from '~types';
+import { MotionStakes, UserStakes } from '~types';
+import { getMotionSide } from '../helpers';
 
 export const getRequiredStake = (
   skillRep: BigNumber,
@@ -40,4 +41,98 @@ export const getRemainingStakes = (
   const remainingYayStake = requiredStake.sub(totalYayStakesRaw).toString();
   const remainingNayStake = requiredStake.sub(totalNayStakesRaw).toString();
   return [remainingNayStake, remainingYayStake];
+};
+
+const getStakePercentage = (
+  stake: BigNumber,
+  requiredStake: BigNumber,
+): BigNumber => stake.div(requiredStake).mul(100);
+
+const getUpdatedUserStakes = (
+  existingUserStakes: UserStakes,
+  amount: BigNumber,
+  vote: BigNumber,
+  requiredStake: BigNumber,
+): UserStakes => {
+  const stakedSide = getMotionSide(vote);
+  const existingRawStake = existingUserStakes.stakes.raw[stakedSide];
+  const updatedRawStake = amount.add(existingRawStake);
+  const updatedPercentage = getStakePercentage(updatedRawStake, requiredStake);
+  const updatedUserStakes: UserStakes = {
+    ...existingUserStakes,
+    stakes: {
+      raw: {
+        ...existingUserStakes.stakes.raw,
+        [stakedSide]: updatedRawStake,
+      },
+      percentage: {
+        ...existingUserStakes.stakes.percentage,
+        [stakedSide]: updatedPercentage,
+      },
+    },
+  };
+
+  return updatedUserStakes;
+};
+
+type UserStakesMapFn = (usersStakes: UserStakes) => UserStakes;
+
+const getUserStakesMapFn =
+  (
+    staker: string,
+    vote: BigNumber,
+    amount: BigNumber,
+    requiredStake: BigNumber,
+  ): UserStakesMapFn =>
+  (userStakes: UserStakes): UserStakes => {
+    const { address } = userStakes;
+
+    if (address === staker) {
+      return getUpdatedUserStakes(userStakes, amount, vote, requiredStake);
+    }
+
+    return userStakes;
+  };
+
+export const getUpdatedUsersStakes = (
+  usersStakes: UserStakes[],
+  staker: string,
+  vote: BigNumber,
+  amount: BigNumber,
+  requiredStake: BigNumber,
+): UserStakes[] => {
+  const isExistingStaker = usersStakes.some(
+    ({ address }) => address === staker,
+  );
+
+  if (isExistingStaker) {
+    const updateUserStakes = getUserStakesMapFn(
+      staker,
+      vote,
+      amount,
+      requiredStake,
+    );
+
+    return usersStakes.map(updateUserStakes);
+  }
+
+  const invertedVote = BigNumber.from(1).sub(vote);
+  const stakedSide = getMotionSide(vote);
+  const unstakedSide = getMotionSide(invertedVote);
+  const newUserStake = {
+    address: staker,
+    stakes: {
+      raw: {
+        [stakedSide]: amount.toString(),
+        [unstakedSide]: '0',
+      },
+
+      percentage: {
+        [stakedSide]: getStakePercentage(amount, requiredStake),
+        [unstakedSide]: '0',
+      },
+    }, // TS doesn't like the computed keys, but we know they're correct
+  } as unknown as UserStakes;
+
+  return [...usersStakes, newUserStake];
 };

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers';
-import { MotionStakes, UserStakes } from '~types';
+import { MotionQuery, MotionStakes, UserStakes } from '~types';
+import { verbose } from '~utils';
 import { getMotionSide } from '../helpers';
 
 export const getRequiredStake = (
@@ -172,4 +173,37 @@ export const getUserMinStake = (
     .mul(userMinStakeFraction)
     .div(BigNumber.from(10).pow(36))
     .toString();
+};
+
+/*
+ * Motion ids are not unique between voting reputation installations. If you had a motion with id of 1
+ * in a previous voting reputation installation, you will get another one after uninstalling and reinstalling
+ * the voting reputation client. So, we only want the one created most recently, since that's the one created
+ * by the currently installed version of the voting reputation extension.
+ */
+
+export const getStakedMotion = (
+  motions: MotionQuery[],
+  motionId: BigNumber,
+): MotionQuery | undefined => {
+  const motionsWithCorrectId = motions.filter(
+    ({ motionData: { motionId: id } }) => id === motionId.toString(),
+  );
+
+  if (motionsWithCorrectId.length > 1) {
+    motionsWithCorrectId.sort(
+      (a, b) =>
+        new Date(a.createdAt).valueOf() - new Date(b.createdAt).valueOf(),
+    );
+  }
+
+  const stakedMotion = motionsWithCorrectId.pop();
+
+  if (!stakedMotion) {
+    verbose(
+      'Could not find the staked motion in the db. This is a bug and needs investigating.',
+    );
+  }
+
+  return stakedMotion;
 };

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -1,0 +1,7 @@
+import { BigNumber } from 'ethers';
+
+export const getRequiredStake = (
+  skillRep: BigNumber,
+  totalStakeFraction: BigNumber,
+): BigNumber =>
+  skillRep.mul(totalStakeFraction).div(BigNumber.from(10).pow(18));

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -12,13 +12,15 @@ export const getMotionStakes = (
   requiredStake: BigNumber,
   [totalNayStakesRaw, totalYayStakesRaw]: [BigNumber, BigNumber],
 ): MotionStakes => {
-  const totalYayStakesPercentage = BigNumber.from(totalYayStakesRaw)
-    .div(requiredStake)
-    .mul(100);
+  const totalYayStakesPercentage = getStakePercentage(
+    totalYayStakesRaw,
+    requiredStake,
+  );
 
-  const totalNayStakesPercentage = BigNumber.from(totalNayStakesRaw)
-    .div(requiredStake)
-    .mul(100);
+  const totalNayStakesPercentage = getStakePercentage(
+    totalNayStakesRaw,
+    requiredStake,
+  );
 
   const motionStakes: MotionStakes = {
     raw: {
@@ -43,10 +45,10 @@ export const getRemainingStakes = (
   return [remainingNayStake, remainingYayStake];
 };
 
-const getStakePercentage = (
+export const getStakePercentage = (
   stake: BigNumber,
   requiredStake: BigNumber,
-): BigNumber => stake.div(requiredStake).mul(100);
+): BigNumber => stake.mul(100).div(requiredStake);
 
 /**
  * Given staking data, format and return new UserStakes object
@@ -94,11 +96,11 @@ const getUpdatedUserStakes = (
     stakes: {
       raw: {
         ...existingUserStakes.stakes.raw,
-        [stakedSide]: updatedRawStake,
+        [stakedSide]: updatedRawStake.toString(),
       },
       percentage: {
         ...existingUserStakes.stakes.percentage,
-        [stakedSide]: updatedPercentage,
+        [stakedSide]: updatedPercentage.toString(),
       },
     },
   };

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -174,36 +174,3 @@ export const getUserMinStake = (
     .div(BigNumber.from(10).pow(36))
     .toString();
 };
-
-/*
- * Motion ids are not unique between voting reputation installations. If you had a motion with id of 1
- * in a previous voting reputation installation, you will get another one after uninstalling and reinstalling
- * the voting reputation client. So, we only want the one created most recently, since that's the one created
- * by the currently installed version of the voting reputation extension.
- */
-
-export const getStakedMotion = (
-  motions: MotionQuery[],
-  motionId: BigNumber,
-): MotionQuery | undefined => {
-  const motionsWithCorrectId = motions.filter(
-    ({ motionData: { motionId: id } }) => id === motionId.toString(),
-  );
-
-  if (motionsWithCorrectId.length > 1) {
-    motionsWithCorrectId.sort(
-      (a, b) =>
-        new Date(a.createdAt).valueOf() - new Date(b.createdAt).valueOf(),
-    );
-  }
-
-  const stakedMotion = motionsWithCorrectId.pop();
-
-  if (!stakedMotion) {
-    verbose(
-      'Could not find the staked motion in the db. This is a bug and needs investigating.',
-    );
-  }
-
-  return stakedMotion;
-};

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -156,3 +156,20 @@ export const getUpdatedUsersStakes = (
 
   return [...usersStakes, newUserStakes];
 };
+
+const getUserMinStake = (
+  totalStakeFraction: BigNumber,
+  userMinStakeFraction: BigNumber,
+  skillRep: BigNumber,
+): string => {
+  /*
+   * Both totalStakeFraction and userMinStakeFraction both divide by 10 to the power of 18.
+   * Since we've multiplied by both, we need to divide by 10 to the power of 18, twice.
+   */
+
+  return skillRep
+    .mul(totalStakeFraction)
+    .mul(userMinStakeFraction)
+    .div(BigNumber.from(10).pow(36))
+    .toString();
+};

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -32,3 +32,12 @@ export const getMotionStakes = (
 
   return motionStakes;
 };
+
+export const getRemainingStakes = (
+  requiredStake: BigNumber,
+  [totalNayStakesRaw, totalYayStakesRaw]: [BigNumber, BigNumber],
+): [string, string] => {
+  const remainingYayStake = requiredStake.sub(totalYayStakesRaw).toString();
+  const remainingNayStake = requiredStake.sub(totalNayStakesRaw).toString();
+  return [remainingNayStake, remainingYayStake];
+};

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -7,6 +7,7 @@ import {
   getMotionStakes,
   getRemainingStakes,
   getRequiredStake,
+  getUpdatedUsersStakes,
 } from '../helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
@@ -33,9 +34,27 @@ export default async (event: ContractEvent): Promise<void> => {
     },
   );
 
-  verbose(
-    `User: ${staker} staked motion ${motionId} by ${amount.toString()} on side ${getMotionSide(
-      vote,
-    )}`,
+  const stakedMotion = motions.find(
+    ({ motionData: { motionId: id } }) => id === motionId.toString(),
   );
+
+  if (stakedMotion) {
+    const {
+      motionData: { usersStakes },
+    } = stakedMotion;
+
+    const updatedUserStakes = getUpdatedUsersStakes(
+      usersStakes,
+      staker,
+      vote,
+      amount,
+      requiredStake,
+    );
+
+    verbose(
+      `User: ${staker} staked motion ${motionId} by ${amount.toString()} on side ${getMotionSide(
+        vote,
+      )}`,
+    );
+  }
 };

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers';
 import { ContractEvent } from '~types';
 import { verbose } from '~utils';
 import { getVotingClient } from '~utils/clients';
@@ -11,9 +12,20 @@ export default async (event: ContractEvent): Promise<void> => {
 
   const votingClient = await getVotingClient(colonyAddress);
   const totalStakeFraction = await votingClient.getTotalStakeFraction();
-  const { skillRep } = await votingClient.getMotion(motionId);
+  const {
+    skillRep,
+    stakes: [totalNayStakesRaw, totalYayStakesRaw],
+  } = await votingClient.getMotion(motionId);
 
   const requiredStake = getRequiredStake(skillRep, totalStakeFraction);
+
+  const totalYayStakesPercentage = BigNumber.from(totalYayStakesRaw)
+    .div(requiredStake)
+    .mul(100);
+
+  const totalNayStakesPercentage = BigNumber.from(totalNayStakesRaw)
+    .div(requiredStake)
+    .mul(100);
 
   verbose(
     `User: ${staker} staked motion ${motionId} by ${amount.toString()} on side ${getMotionSide(

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,4 +1,5 @@
-import { ContractEvent } from '~types';
+import { query } from '~amplifyClient';
+import { ContractEvent, MotionQuery } from '~types';
 import { verbose } from '~utils';
 import { getVotingClient } from '~utils/clients';
 import {
@@ -23,6 +24,13 @@ export default async (event: ContractEvent): Promise<void> => {
   const [remainingNayStake, remainingYayStake] = getRemainingStakes(
     requiredStake,
     stakes,
+  );
+
+  const { items: motions }: { items: MotionQuery[] } = await query(
+    'getColonyMotions',
+    {
+      colonyAddress,
+    },
   );
 
   verbose(

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,8 +1,7 @@
-import { BigNumber } from 'ethers';
 import { ContractEvent } from '~types';
 import { verbose } from '~utils';
 import { getVotingClient } from '~utils/clients';
-import { getMotionSide, getRequiredStake } from '../helpers';
+import { getMotionSide, getMotionStakes, getRequiredStake } from '../helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
@@ -12,20 +11,10 @@ export default async (event: ContractEvent): Promise<void> => {
 
   const votingClient = await getVotingClient(colonyAddress);
   const totalStakeFraction = await votingClient.getTotalStakeFraction();
-  const {
-    skillRep,
-    stakes: [totalNayStakesRaw, totalYayStakesRaw],
-  } = await votingClient.getMotion(motionId);
+  const { skillRep, stakes } = await votingClient.getMotion(motionId);
 
   const requiredStake = getRequiredStake(skillRep, totalStakeFraction);
-
-  const totalYayStakesPercentage = BigNumber.from(totalYayStakesRaw)
-    .div(requiredStake)
-    .mul(100);
-
-  const totalNayStakesPercentage = BigNumber.from(totalNayStakesRaw)
-    .div(requiredStake)
-    .mul(100);
+  const motionStakes = getMotionStakes(requiredStake, stakes);
 
   verbose(
     `User: ${staker} staked motion ${motionId} by ${amount.toString()} on side ${getMotionSide(

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,7 +1,12 @@
 import { ContractEvent } from '~types';
 import { verbose } from '~utils';
 import { getVotingClient } from '~utils/clients';
-import { getMotionSide, getMotionStakes, getRequiredStake } from '../helpers';
+import {
+  getMotionSide,
+  getMotionStakes,
+  getRemainingStakes,
+  getRequiredStake,
+} from '../helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
@@ -15,6 +20,10 @@ export default async (event: ContractEvent): Promise<void> => {
 
   const requiredStake = getRequiredStake(skillRep, totalStakeFraction);
   const motionStakes = getMotionStakes(requiredStake, stakes);
+  const [remainingNayStake, remainingYayStake] = getRemainingStakes(
+    requiredStake,
+    stakes,
+  );
 
   verbose(
     `User: ${staker} staked motion ${motionId} by ${amount.toString()} on side ${getMotionSide(

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,6 +1,7 @@
 import { ContractEvent } from '~types';
-import { verbose, getVotingClient, getMotionDatabaseId } from '~utils';
+import { verbose, getVotingClient } from '~utils';
 import {
+  getMotionDatabaseId,
   getMotionFromDB,
   getMotionSide,
   getMotionStakes,

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,5 +1,5 @@
 import { ContractEvent } from '~types';
-import { verbose, getVotingClient } from '~utils';
+import { verbose, getVotingClient, getMotionDatabaseId } from '~utils';
 import {
   getMotionFromDB,
   getMotionSide,
@@ -24,7 +24,13 @@ export default async (event: ContractEvent): Promise<void> => {
   const motionStakes = getMotionStakes(requiredStake, stakes);
   const remainingStakes = getRemainingStakes(requiredStake, stakes);
 
-  const stakedMotion = await getMotionFromDB(colonyAddress, motionId);
+  const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
+  const stakedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
 
   if (stakedMotion) {
     const {

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,11 +1,19 @@
 import { ContractEvent } from '~types';
 import { verbose } from '~utils';
-import { getMotionSide } from '../helpers';
+import { getVotingClient } from '~utils/clients';
+import { getMotionSide, getRequiredStake } from '../helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
+    contractAddress: colonyAddress,
     args: { vote, amount, staker, motionId },
   } = event;
+
+  const votingClient = await getVotingClient(colonyAddress);
+  const totalStakeFraction = await votingClient.getTotalStakeFraction();
+  const { skillRep } = await votingClient.getMotion(motionId);
+
+  const requiredStake = getRequiredStake(skillRep, totalStakeFraction);
 
   verbose(
     `User: ${staker} staked motion ${motionId} by ${amount.toString()} on side ${getMotionSide(

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -6,6 +6,7 @@ import {
   getMotionStakes,
   getRemainingStakes,
   getRequiredStake,
+  getStakedMotion,
   getUpdatedUsersStakes,
   updateMotionInDB,
 } from '../helpers';
@@ -31,9 +32,7 @@ export default async (event: ContractEvent): Promise<void> => {
     },
   );
 
-  const stakedMotion = motions.find(
-    ({ motionData: { motionId: id } }) => id === motionId.toString(),
-  );
+  const stakedMotion = getStakedMotion(motions, motionId);
 
   if (stakedMotion) {
     const {

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,12 +1,11 @@
-import { query } from '~amplifyClient';
-import { ContractEvent, MotionQuery } from '~types';
+import { ContractEvent } from '~types';
 import { verbose, getVotingClient } from '~utils';
 import {
+  getMotionFromDB,
   getMotionSide,
   getMotionStakes,
   getRemainingStakes,
   getRequiredStake,
-  getStakedMotion,
   getUpdatedUsersStakes,
   updateMotionInDB,
 } from '../helpers';
@@ -25,14 +24,7 @@ export default async (event: ContractEvent): Promise<void> => {
   const motionStakes = getMotionStakes(requiredStake, stakes);
   const remainingStakes = getRemainingStakes(requiredStake, stakes);
 
-  const { items: motions }: { items: MotionQuery[] } = await query(
-    'getColonyMotions',
-    {
-      colonyAddress,
-    },
-  );
-
-  const stakedMotion = getStakedMotion(motions, motionId);
+  const stakedMotion = await getMotionFromDB(colonyAddress, motionId);
 
   if (stakedMotion) {
     const {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,7 @@ export enum ContractEventsSignatures {
   // Motions
   MotionCreated = 'MotionCreated(uint256,address,uint256)',
   MotionStaked = 'MotionStaked(uint256,address,uint256,uint256)',
+  MotionFinalized = 'MotionFinalized(uint256,bytes,bool)',
 }
 
 /*

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,6 +63,7 @@ export enum ContractEventsSignatures {
   MotionCreated = 'MotionCreated(uint256,address,uint256)',
   MotionStaked = 'MotionStaked(uint256,address,uint256,uint256)',
   MotionFinalized = 'MotionFinalized(uint256,bytes,bool)',
+  MotionRewardClaimed = 'MotionRewardClaimed(uint256,address,uint256,uint256)',
 }
 
 /*

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -46,11 +46,18 @@ export interface MotionData {
   // For calculating user's max stake in client
   rootHash: string;
   motionDomainId: string;
+  stakerRewards: StakerReward[];
+  isFinalized: boolean;
 }
 
 export interface UserStakes {
   address: string;
   stakes: MotionStakes;
+}
+
+export interface StakerReward {
+  address: string;
+  rewards: MotionStakeFragment;
 }
 
 export interface MotionQuery {

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -39,6 +39,13 @@ export interface MotionStakes {
 export interface MotionData {
   motionId: string;
   usersStakes: UserStakes[];
+  motionStakes: MotionStakes;
+  remainingStakes: [string, string];
+  userMinStake: string;
+  requiredStake: string;
+  // For calculating user's max stake in client
+  rootHash: string;
+  motionDomainId: string;
 }
 
 export interface UserStakes {

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -25,3 +25,13 @@ export const motionNameMapping: { [key: string]: ColonyActionType } = {
   // emitDomainReputationPenalty: ColonyMotions.EmitDomainReputationPenaltyMotion,
   // emitDomainReputationReward: ColonyMotions.EmitDomainReputationRewardMotion,
 };
+
+interface MotionStakeFragment {
+  [MotionSide.NAY]: string;
+  [MotionSide.YAY]: string;
+}
+
+export interface MotionStakes {
+  raw: MotionStakeFragment;
+  percentage: MotionStakeFragment;
+}

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -5,6 +5,11 @@ export enum MotionSide {
   NAY = 'nay',
 }
 
+export enum MotionVote {
+  NAY,
+  YAY,
+}
+
 /*
  * Contract calls
  */

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -36,7 +36,7 @@ export interface MotionStakes {
   percentage: MotionStakeFragment;
 }
 
-interface MotionData {
+export interface MotionData {
   motionId: string;
   usersStakes: UserStakes[];
 }

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -35,3 +35,18 @@ export interface MotionStakes {
   raw: MotionStakeFragment;
   percentage: MotionStakeFragment;
 }
+
+interface MotionData {
+  motionId: string;
+  usersStakes: UserStakes[];
+}
+
+export interface UserStakes {
+  address: string;
+  stakes: MotionStakes;
+}
+
+export interface MotionQuery {
+  id: string;
+  motionData: MotionData;
+}

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -56,4 +56,5 @@ export interface UserStakes {
 export interface MotionQuery {
   id: string;
   motionData: MotionData;
+  createdAt: string;
 }

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -43,6 +43,7 @@ export interface MotionStakes {
 
 export interface MotionData {
   motionId: string;
+  nativeMotionId: string;
   usersStakes: UserStakes[];
   motionStakes: MotionStakes;
   remainingStakes: [string, string];
@@ -53,6 +54,7 @@ export interface MotionData {
   motionDomainId: string;
   stakerRewards: StakerReward[];
   isFinalized: boolean;
+  createdBy: string;
 }
 
 export interface UserStakes {

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -63,6 +63,7 @@ export interface UserStakes {
 export interface StakerReward {
   address: string;
   rewards: MotionStakeFragment;
+  isClaimed: boolean;
 }
 
 export interface MotionQuery {

--- a/src/utils/clients.ts
+++ b/src/utils/clients.ts
@@ -1,0 +1,9 @@
+import { AnyVotingReputationClient, Extension } from '@colony/colony-js';
+import networkClient from '../networkClient';
+
+export const getVotingClient = async (
+  colonyAddress: string,
+): Promise<AnyVotingReputationClient> => {
+  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  return await colonyClient.getExtensionClient(Extension.VotingReputation);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,5 @@ export * from './numbers';
 export * from './tokens';
 export * from './actions';
 export * from './domains';
-export * from './motions';
 export * from './events';
 export * from './clients';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './actions';
 export * from './domains';
 export * from './motions';
 export * from './events';
+export * from './clients';

--- a/src/utils/motions.ts
+++ b/src/utils/motions.ts
@@ -69,6 +69,8 @@ const getMotionData = async (
     userMinStake,
     rootHash,
     motionDomainId: domainId.toString(),
+    stakerRewards: [],
+    isFinalized: false,
   };
 };
 


### PR DESCRIPTION
This PR handles the database mutation for the MotionStaked event.

It introduces a number of helpers in order to calculate the latest staking data, for consumption by the staking widget in the front end, and then mutates the motionData field of the corresponding ColonyAction.

Test with [port/270-update-ui-after-staking](https://github.com/JoinColony/colonyCDapp/pull/338)