### PR TITLE
Cache colony clients

### DIFF
--- a/src/handlers/actions/createDomain.ts
+++ b/src/handlers/actions/createDomain.ts
@@ -1,7 +1,11 @@
 import { mutate } from '~amplifyClient';
-import networkClient from '~networkClient';
 import { ColonyActionType, ContractEvent } from '~types';
-import { toNumber, writeActionFromEvent, getDomainDatabaseId } from '~utils';
+import {
+  toNumber,
+  writeActionFromEvent,
+  getDomainDatabaseId,
+  getCachedColonyClient,
+} from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { contractAddress: colonyAddress } = event;
@@ -9,7 +13,7 @@ export default async (event: ContractEvent): Promise<void> => {
   const nativeDomainId = toNumber(domainId);
   const databaseDomainId = getDomainDatabaseId(colonyAddress, nativeDomainId);
 
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const colonyClient = await getCachedColonyClient(colonyAddress);
   const [skillId, fundingPotId] = await colonyClient.getDomain(nativeDomainId);
 
   await mutate('createDomain', {

--- a/src/handlers/actions/emitDomainReputation.ts
+++ b/src/handlers/actions/emitDomainReputation.ts
@@ -1,12 +1,20 @@
 import { BigNumber } from 'ethers';
 import { AnyColonyClient, getEvents } from '@colony/colony-js';
 
-import networkClient from '~networkClient';
 import { ColonyActionType, ContractEvent } from '~types';
-import { writeActionFromEvent, getDomainDatabaseId, verbose } from '~utils';
+import {
+  writeActionFromEvent,
+  getDomainDatabaseId,
+  verbose,
+  getCachedColonyClient,
+} from '~utils';
 import { LogDescription } from 'ethers/lib/utils';
 
-const getChangeDomainId = async (domainAddedEvents: LogDescription[], colonyClient: AnyColonyClient, skillId: number): Promise<number | null> => {
+const getChangeDomainId = async (
+  domainAddedEvents: LogDescription[],
+  colonyClient: AnyColonyClient,
+  skillId: number,
+): Promise<number | null> => {
   for (const event of domainAddedEvents) {
     const domainId = event.args.domainId.toString();
     const { skillId: domainSkillId } = await colonyClient.getDomain(domainId);
@@ -19,16 +27,27 @@ const getChangeDomainId = async (domainAddedEvents: LogDescription[], colonyClie
 
 export default async (event: ContractEvent): Promise<void> => {
   const { contractAddress: colonyAddress } = event;
-  const { agent: initiatorAddress, user: userAddress, skillId, amount } = event.args;
+  const {
+    agent: initiatorAddress,
+    user: userAddress,
+    skillId,
+    amount,
+  } = event.args;
 
   const isReputationChangePositive = BigNumber.from(amount).gt(0);
 
-  const actionType = isReputationChangePositive ? ColonyActionType.EmitDomainReputationReward : ColonyActionType.EmitDomainReputationPenalty;
+  const actionType = isReputationChangePositive
+    ? ColonyActionType.EmitDomainReputationReward
+    : ColonyActionType.EmitDomainReputationPenalty;
 
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const colonyClient = await getCachedColonyClient(colonyAddress);
   const domainAddedFilter = colonyClient.filters.DomainAdded(null, null);
   const domainAddedEvents = await getEvents(colonyClient, domainAddedFilter);
-  const changeDomainId = await getChangeDomainId(domainAddedEvents, colonyClient, skillId);
+  const changeDomainId = await getChangeDomainId(
+    domainAddedEvents,
+    colonyClient,
+    skillId,
+  );
 
   if (!changeDomainId) {
     verbose(

--- a/src/handlers/actions/moveFunds.ts
+++ b/src/handlers/actions/moveFunds.ts
@@ -7,7 +7,6 @@ import {
 } from '@colony/colony-js';
 import { BigNumber, utils } from 'ethers';
 
-import networkClient from '~networkClient';
 import {
   ColonyActionType,
   ContractEvent,
@@ -18,6 +17,7 @@ import {
   writeActionFromEvent,
   getDomainDatabaseId,
   verbose,
+  getCachedColonyClient,
 } from '~utils';
 import provider from '~provider';
 
@@ -57,7 +57,7 @@ export default async (event: ContractEvent): Promise<void> => {
     toPot,
   } = event.args;
 
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const colonyClient = await getCachedColonyClient(colonyAddress);
   let fromDomainId: BigNumber | undefined;
   let toDomainId: BigNumber | undefined;
   if (isSupportedColonyClient(colonyClient)) {

--- a/src/handlers/actions/payment.ts
+++ b/src/handlers/actions/payment.ts
@@ -1,6 +1,5 @@
 import { utils } from 'ethers';
 
-import networkClient from '~networkClient';
 import provider from '~provider';
 import {
   ColonyActionType,
@@ -13,6 +12,7 @@ import {
   toNumber,
   mapLogToContractEvent,
   getDomainDatabaseId,
+  getCachedColonyClient,
 } from '~utils';
 
 const events = [
@@ -26,7 +26,7 @@ const hashedSignatures = events.map((signature) => utils.id(signature));
 export default async (paymentAddedEvent: ContractEvent): Promise<void> => {
   const { contractAddress: colonyAddress, transactionHash } = paymentAddedEvent;
 
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const colonyClient = await getCachedColonyClient(colonyAddress);
 
   const receipt = await provider.getTransactionReceipt(transactionHash);
   const [, payoutClaimedLog, oneTxPaymentMadeLog] = receipt.logs.filter((log) =>

--- a/src/handlers/actions/unlockToken.ts
+++ b/src/handlers/actions/unlockToken.ts
@@ -1,13 +1,16 @@
 import { Id } from '@colony/colony-js';
-import networkClient from '~networkClient';
 import { ColonyActionType, ContractEvent } from '~types';
-import { writeActionFromEvent, getDomainDatabaseId } from '~utils';
+import {
+  writeActionFromEvent,
+  getDomainDatabaseId,
+  getCachedColonyClient,
+} from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { contractAddress: colonyAddress } = event;
   const { agent: initiatorAddress } = event.args;
 
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const colonyClient = await getCachedColonyClient(colonyAddress);
   const tokenAddress = await colonyClient.getToken();
 
   await writeActionFromEvent(event, colonyAddress, {

--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import { getLogs } from '@colony/colony-js';
 
-import networkClient from './networkClient';
+import networkClient from '~networkClient';
 import {
   output,
   writeJsonStats,
@@ -9,11 +9,12 @@ import {
   addNetworkEventListener,
   setToJS,
   toNumber,
-} from './utils';
-import { colonySpecificEventsListener } from './eventListener';
-import { ContractEventsSignatures } from './types';
-import { mutate } from './amplifyClient';
-import { COLONY_CURRENT_VERSION_KEY } from './constants';
+} from '~utils';
+import { colonySpecificEventsListener } from '~eventListener';
+import { ContractEventsSignatures } from '~types';
+import { mutate } from '~amplifyClient';
+import { COLONY_CURRENT_VERSION_KEY } from '~constants';
+import trackColonyActions from '~trackColonyActions';
 
 dotenv.config();
 
@@ -52,10 +53,11 @@ export default async (): Promise<void> => {
    * Once we found all current colonies, setup all Colony related listeners we care about
    */
   await Promise.all(
-    setToJS(coloniesSet).map(
-      async ({ colonyAddress }) =>
-        await colonySpecificEventsListener(colonyAddress),
-    ),
+    setToJS(coloniesSet).map(async ({ colonyAddress }) => {
+      await trackColonyActions(colonyAddress);
+
+      await colonySpecificEventsListener(colonyAddress);
+    }),
   );
 
   /*

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -1,0 +1,99 @@
+import { getLogs } from '@colony/colony-js';
+import { utils } from 'ethers';
+
+import {
+  handleCreateDomainAction,
+  handleEditColonyAction,
+  handleEditDomainAction,
+  handleEmitDomainReputationAction,
+  handleMintTokensAction,
+  handleMoveFundsAction,
+  handlePaymentAction,
+  handleTokenUnlockedAction,
+  handleVersionUpgradeAction,
+} from '~handlers';
+import networkClient from '~networkClient';
+import { ColonyActionHandler, ContractEventsSignatures, Filter } from '~types';
+import { getCachedColonyClient, mapLogToContractEvent, verbose } from '~utils';
+
+const getFilter = (
+  eventSignature: ContractEventsSignatures,
+  colonyAddress: string,
+): Filter => ({
+  topics: [utils.id(eventSignature)],
+  address: colonyAddress,
+});
+
+/**
+ * This function get logs for a particular event, parses them and call a relevant action handler to act upon it
+ *
+ * @NOTE This can only work with an archive node, as well as one that can display more than 10000 events.
+ * Most commercial solutions out there limit to around 10k events in the past, plus that not everyone will give up an archive node.
+ * So this can only work with our custom, nethermind based node.
+ */
+const trackActionsByEvent = async (
+  eventSignature: ContractEventsSignatures,
+  colonyAddress: string,
+  handler: ColonyActionHandler,
+): Promise<void> => {
+  const colonyClient = await getCachedColonyClient(colonyAddress);
+  const filter = getFilter(eventSignature, colonyAddress);
+  const logs = await getLogs(networkClient, filter);
+  logs.forEach(async (log) => {
+    const event = await mapLogToContractEvent(log, colonyClient.interface);
+    if (!event) {
+      return;
+    }
+
+    handler(event);
+  });
+};
+
+export default async (colonyAddress: string): Promise<void> => {
+  verbose('Fetching past actions for colony:', colonyAddress);
+  await trackActionsByEvent(
+    ContractEventsSignatures.TokensMinted,
+    colonyAddress,
+    handleMintTokensAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.PaymentAdded,
+    colonyAddress,
+    handlePaymentAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.TokenUnlocked,
+    colonyAddress,
+    handleTokenUnlockedAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.DomainAdded,
+    colonyAddress,
+    handleCreateDomainAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.DomainMetadata,
+    colonyAddress,
+    handleEditDomainAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ColonyFundsMovedBetweenFundingPots,
+    colonyAddress,
+    handleMoveFundsAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ColonyMetadata,
+    colonyAddress,
+    handleEditColonyAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ColonyUpgraded,
+    colonyAddress,
+    handleVersionUpgradeAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ArbitraryReputationUpdate,
+    colonyAddress,
+    handleEmitDomainReputationAction,
+  );
+};

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -1,8 +1,9 @@
 import { Extension, getExtensionHash, getLogs } from '@colony/colony-js';
 
-import networkClient from './networkClient';
+import networkClient from '~networkClient';
 import {
   deleteExtensionFromEvent,
+  getCachedColonyClient,
   isExtensionDeprecated,
   isExtensionInitialised,
   mapLogToContractEvent,
@@ -10,9 +11,9 @@ import {
   verbose,
   writeExtensionFromEvent,
   writeExtensionVersionFromEvent,
-} from './utils';
-import { SUPPORTED_EXTENSION_IDS } from './constants';
-import { extensionSpecificEventsListener } from './eventListener';
+} from '~utils';
+import { SUPPORTED_EXTENSION_IDS } from '~constants';
+import { extensionSpecificEventsListener } from '~eventListener';
 
 export default async (): Promise<void> => {
   // @TODO: Set to the latest block processed by block-ingestor
@@ -156,7 +157,7 @@ const trackExtensionEvents = async (
      */
     const version = await (
       await (
-        await networkClient.getColonyClient(colony)
+        await getCachedColonyClient(colony)
       ).getExtensionClient(extensionId)
     ).version();
     const convertedVersion = toNumber(version);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { getLogs } from '@colony/colony-js';
 import { LogDescription } from '@ethersproject/abi';
 
 /*
@@ -80,3 +81,8 @@ export enum ColonyActionType {
   EmitDomainReputationPenalty = 'EMIT_DOMAIN_REPUTATION_PENALTY',
   EmitDomainReputationReward = 'EMIT_DOMAIN_REPUTATION_REWARD',
 }
+
+export type ColonyActionHandler = (event: ContractEvent) => Promise<void>;
+
+// The Filter type doesn't seem to be exported from colony-js
+export type Filter = Parameters<typeof getLogs>[1];

--- a/src/utils/colonyClient.ts
+++ b/src/utils/colonyClient.ts
@@ -1,0 +1,21 @@
+import { AnyColonyClient } from '@colony/colony-js';
+
+import networkClient from '~networkClient';
+
+const colonyClientsCache: Record<string, AnyColonyClient> = {};
+
+/**
+ * Method attempting to return a cached colony client,
+ * or get one from the networkClient if there's no cached entry
+ */
+export const getCachedColonyClient = async (
+  colonyAddress: string,
+): Promise<AnyColonyClient> => {
+  if (colonyAddress in colonyClientsCache) {
+    return colonyClientsCache[colonyAddress];
+  }
+
+  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  colonyClientsCache[colonyAddress] = colonyClient;
+  return colonyClient;
+};

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -9,7 +9,7 @@ import {
 } from '@colony/colony-js';
 
 import networkClient from '~networkClient';
-import { ContractEvent, ContractEventsSignatures } from '~types';
+import { ContractEvent, ContractEventsSignatures, Filter } from '~types';
 import { addEvent } from '~eventQueue';
 import { mutate, query } from '~amplifyClient';
 import { getChainId } from '~provider';
@@ -42,13 +42,13 @@ export const eventListenerGenerator = async (
     client = await getCachedColonyClient(contractAddress);
   }
 
-  const filter: { topics: Array<string | null>; address?: string } = {
+  const filter: Filter = {
     topics: [utils.id(eventSignature)],
   };
 
   if (clientType === ClientType.TokenClient) {
     filter.topics = [
-      ...filter.topics,
+      ...(filter.topics ?? []),
       null,
       utils.hexZeroPad(contractAddress, 32),
     ];

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -16,6 +16,7 @@ import { getChainId } from '~provider';
 
 import { getExtensionContract } from './extensions';
 import { verbose } from './logger';
+import { getCachedColonyClient } from './colonyClient';
 
 /*
  * Convert a Set that contains a JSON string, back into JS form
@@ -38,7 +39,7 @@ export const eventListenerGenerator = async (
   let client: ColonyNetworkClient | TokenClient | AnyColonyClient =
     networkClient;
   if (clientType === ClientType.ColonyClient && contractAddress) {
-    client = await networkClient.getColonyClient(contractAddress);
+    client = await getCachedColonyClient(contractAddress);
   }
 
   const filter: { topics: Array<string | null>; address?: string } = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './numbers';
 export * from './tokens';
 export * from './actions';
 export * from './domains';
+export * from './colonyClient';

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,9 +1,9 @@
-import networkClient from '~networkClient';
+import { getCachedColonyClient } from './colonyClient';
 
 export const getColonyTokenAddress = async (
   colonyAddress: string,
 ): Promise<string> => {
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const colonyClient = await getCachedColonyClient(colonyAddress);
   const tokenAddress = await colonyClient.getToken();
   return tokenAddress;
 };


### PR DESCRIPTION
This PR adds caching of colony clients. It was originally suggested by Raul in one of my PRs and it made sense to do it now as I found myself calling `getColonyClient` in different methods for the same colony

Resolves #25 