### PR TITLE
Track past actions 

### DIFF
--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import { getLogs } from '@colony/colony-js';
 
-import networkClient from './networkClient';
+import networkClient from '~networkClient';
 import {
   output,
   writeJsonStats,
@@ -9,11 +9,12 @@ import {
   addNetworkEventListener,
   setToJS,
   toNumber,
-} from './utils';
-import { colonySpecificEventsListener } from './eventListener';
-import { ContractEventsSignatures } from './types';
-import { mutate } from './amplifyClient';
-import { COLONY_CURRENT_VERSION_KEY } from './constants';
+} from '~utils';
+import { colonySpecificEventsListener } from '~eventListener';
+import { ContractEventsSignatures } from '~types';
+import { mutate } from '~amplifyClient';
+import { COLONY_CURRENT_VERSION_KEY } from '~constants';
+import trackColonyActions from '~trackColonyActions';
 
 dotenv.config();
 
@@ -52,10 +53,11 @@ export default async (): Promise<void> => {
    * Once we found all current colonies, setup all Colony related listeners we care about
    */
   await Promise.all(
-    setToJS(coloniesSet).map(
-      async ({ colonyAddress }) =>
-        await colonySpecificEventsListener(colonyAddress),
-    ),
+    setToJS(coloniesSet).map(async ({ colonyAddress }) => {
+      await trackColonyActions(colonyAddress);
+
+      await colonySpecificEventsListener(colonyAddress);
+    }),
   );
 
   /*

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -3,6 +3,7 @@ import { utils } from 'ethers';
 
 import {
   handleMintTokensAction,
+  handleMoveFundsAction,
   handlePaymentAction,
   handleTokenUnlockedAction,
 } from '~handlers';
@@ -56,5 +57,10 @@ export default async (colonyAddress: string): Promise<void> => {
     ContractEventsSignatures.TokenUnlocked,
     colonyAddress,
     handleTokenUnlockedAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ColonyFundsMovedBetweenFundingPots,
+    colonyAddress,
+    handleMoveFundsAction,
   );
 };

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -1,0 +1,25 @@
+import { getLogs } from '@colony/colony-js';
+import { utils } from 'ethers';
+
+import { handleMintTokensAction } from '~handlers';
+import networkClient from '~networkClient';
+import { ContractEventsSignatures } from '~types';
+import { mapLogToContractEvent, verbose } from '~utils';
+
+export default async (colonyAddress: string): Promise<void> => {
+  verbose('Fetching past actions for colony:', colonyAddress);
+  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const tokensMintedFilter = {
+    topics: [utils.id(ContractEventsSignatures.TokensMinted)],
+    address: colonyAddress,
+  };
+  const tokensMintedLogs = await getLogs(networkClient, tokensMintedFilter);
+  tokensMintedLogs.forEach(async (log) => {
+    const event = await mapLogToContractEvent(log, colonyClient.interface);
+    if (!event) {
+      return;
+    }
+
+    await handleMintTokensAction(event);
+  });
+};

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -9,6 +9,7 @@ import {
   handleMoveFundsAction,
   handlePaymentAction,
   handleTokenUnlockedAction,
+  handleVersionUpgradeAction,
 } from '~handlers';
 import networkClient from '~networkClient';
 import { ColonyActionHandler, ContractEventsSignatures } from '~types';
@@ -79,5 +80,10 @@ export default async (colonyAddress: string): Promise<void> => {
     ContractEventsSignatures.ColonyMetadata,
     colonyAddress,
     handleEditColonyAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ColonyUpgraded,
+    colonyAddress,
+    handleVersionUpgradeAction,
   );
 };

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -24,6 +24,13 @@ const getFilter = (
   address: colonyAddress,
 });
 
+/**
+ * This function get logs for a particular event, parses them and call a relevant action handler to act upon it
+ *
+ * @NOTE This can only work with an archive node, as well as one that can display more than 10000 events.
+ * Most commercial solutions out there limit to around 10k events in the past, plus that not everyone will give up an archive node.
+ * So this can only work with our custom, nethermind based node.
+ */
 const trackActionsByEvent = async (
   eventSignature: ContractEventsSignatures,
   colonyAddress: string,

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -13,11 +13,8 @@ import {
   handleVersionUpgradeAction,
 } from '~handlers';
 import networkClient from '~networkClient';
-import { ColonyActionHandler, ContractEventsSignatures } from '~types';
+import { ColonyActionHandler, ContractEventsSignatures, Filter } from '~types';
 import { getCachedColonyClient, mapLogToContractEvent, verbose } from '~utils';
-
-// The Filter type doesn't seem to be exported from colony-js
-type Filter = Parameters<typeof getLogs>[1];
 
 const getFilter = (
   eventSignature: ContractEventsSignatures,

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -1,4 +1,4 @@
-import { getLogs } from '@colony/colony-js';
+import { AnyColonyClient, getLogs } from '@colony/colony-js';
 import { utils } from 'ethers';
 
 import { handleMintTokensAction } from '~handlers';
@@ -6,9 +6,10 @@ import networkClient from '~networkClient';
 import { ContractEventsSignatures } from '~types';
 import { mapLogToContractEvent, verbose } from '~utils';
 
-export default async (colonyAddress: string): Promise<void> => {
-  verbose('Fetching past actions for colony:', colonyAddress);
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+const trackMintTokensActions = async (
+  colonyAddress: string,
+  colonyClient: AnyColonyClient,
+): Promise<void> => {
   const tokensMintedFilter = {
     topics: [utils.id(ContractEventsSignatures.TokensMinted)],
     address: colonyAddress,
@@ -22,4 +23,9 @@ export default async (colonyAddress: string): Promise<void> => {
 
     await handleMintTokensAction(event);
   });
+};
+
+export default async (colonyAddress: string): Promise<void> => {
+  verbose('Fetching past actions for colony:', colonyAddress);
+  const colonyClient = await networkClient.getColonyClient(colonyAddress);
 };

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -5,6 +5,7 @@ import {
   handleCreateDomainAction,
   handleEditColonyAction,
   handleEditDomainAction,
+  handleEmitDomainReputationAction,
   handleMintTokensAction,
   handleMoveFundsAction,
   handlePaymentAction,
@@ -85,5 +86,10 @@ export default async (colonyAddress: string): Promise<void> => {
     ContractEventsSignatures.ColonyUpgraded,
     colonyAddress,
     handleVersionUpgradeAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ArbitraryReputationUpdate,
+    colonyAddress,
+    handleEmitDomainReputationAction,
   );
 };

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -1,19 +1,30 @@
 import { AnyColonyClient, getLogs } from '@colony/colony-js';
 import { utils } from 'ethers';
 
-import { handleMintTokensAction } from '~handlers';
+import { handleMintTokensAction, handlePaymentAction } from '~handlers';
 import networkClient from '~networkClient';
 import { ContractEventsSignatures } from '~types';
 import { mapLogToContractEvent, verbose } from '~utils';
+
+// The Filter type doesn't seem to be exported from colony-js
+type Filter = Parameters<typeof getLogs>[1];
+
+const getFilter = (
+  eventSignature: ContractEventsSignatures,
+  colonyAddress: string,
+): Filter => ({
+  topics: [utils.id(eventSignature)],
+  address: colonyAddress,
+});
 
 const trackMintTokensActions = async (
   colonyAddress: string,
   colonyClient: AnyColonyClient,
 ): Promise<void> => {
-  const tokensMintedFilter = {
-    topics: [utils.id(ContractEventsSignatures.TokensMinted)],
-    address: colonyAddress,
-  };
+  const tokensMintedFilter = getFilter(
+    ContractEventsSignatures.TokensMinted,
+    colonyAddress,
+  );
   const tokensMintedLogs = await getLogs(networkClient, tokensMintedFilter);
   tokensMintedLogs.forEach(async (log) => {
     const event = await mapLogToContractEvent(log, colonyClient.interface);
@@ -25,7 +36,28 @@ const trackMintTokensActions = async (
   });
 };
 
+const trackCreatePaymentActions = async (
+  colonyAddress: string,
+  colonyClient: AnyColonyClient,
+): Promise<void> => {
+  const paymentAddedFilter = getFilter(
+    ContractEventsSignatures.PaymentAdded,
+    colonyAddress,
+  );
+  const paymentAddedLogs = await getLogs(networkClient, paymentAddedFilter);
+  paymentAddedLogs.forEach(async (log) => {
+    const event = await mapLogToContractEvent(log, colonyClient.interface);
+    if (!event) {
+      return;
+    }
+
+    await handlePaymentAction(event);
+  });
+};
+
 export default async (colonyAddress: string): Promise<void> => {
   verbose('Fetching past actions for colony:', colonyAddress);
   const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  await trackMintTokensActions(colonyAddress, colonyClient);
+  await trackCreatePaymentActions(colonyAddress, colonyClient);
 };

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -4,7 +4,7 @@ import { utils } from 'ethers';
 import { handleMintTokensAction, handlePaymentAction } from '~handlers';
 import networkClient from '~networkClient';
 import { ContractEventsSignatures } from '~types';
-import { mapLogToContractEvent, verbose } from '~utils';
+import { getCachedColonyClient, mapLogToContractEvent, verbose } from '~utils';
 
 // The Filter type doesn't seem to be exported from colony-js
 type Filter = Parameters<typeof getLogs>[1];
@@ -57,7 +57,7 @@ const trackCreatePaymentActions = async (
 
 export default async (colonyAddress: string): Promise<void> => {
   verbose('Fetching past actions for colony:', colonyAddress);
-  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+  const colonyClient = await getCachedColonyClient(colonyAddress);
   await trackMintTokensActions(colonyAddress, colonyClient);
   await trackCreatePaymentActions(colonyAddress, colonyClient);
 };

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -2,6 +2,8 @@ import { getLogs } from '@colony/colony-js';
 import { utils } from 'ethers';
 
 import {
+  handleCreateDomainAction,
+  handleEditDomainAction,
   handleMintTokensAction,
   handleMoveFundsAction,
   handlePaymentAction,
@@ -31,7 +33,6 @@ const trackActionsByEvent = async (
   const filter = getFilter(eventSignature, colonyAddress);
   const logs = await getLogs(networkClient, filter);
   logs.forEach(async (log) => {
-    console.log(log);
     const event = await mapLogToContractEvent(log, colonyClient.interface);
     if (!event) {
       return;
@@ -57,6 +58,16 @@ export default async (colonyAddress: string): Promise<void> => {
     ContractEventsSignatures.TokenUnlocked,
     colonyAddress,
     handleTokenUnlockedAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.DomainAdded,
+    colonyAddress,
+    handleCreateDomainAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.DomainMetadata,
+    colonyAddress,
+    handleEditDomainAction,
   );
   await trackActionsByEvent(
     ContractEventsSignatures.ColonyFundsMovedBetweenFundingPots,

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -3,6 +3,7 @@ import { utils } from 'ethers';
 
 import {
   handleCreateDomainAction,
+  handleEditColonyAction,
   handleEditDomainAction,
   handleMintTokensAction,
   handleMoveFundsAction,
@@ -73,5 +74,10 @@ export default async (colonyAddress: string): Promise<void> => {
     ContractEventsSignatures.ColonyFundsMovedBetweenFundingPots,
     colonyAddress,
     handleMoveFundsAction,
+  );
+  await trackActionsByEvent(
+    ContractEventsSignatures.ColonyMetadata,
+    colonyAddress,
+    handleEditColonyAction,
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { getLogs } from '@colony/colony-js';
 import { LogDescription } from '@ethersproject/abi';
 
 /*
@@ -82,3 +83,6 @@ export enum ColonyActionType {
 }
 
 export type ColonyActionHandler = (event: ContractEvent) => Promise<void>;
+
+// The Filter type doesn't seem to be exported from colony-js
+export type Filter = Parameters<typeof getLogs>[1];

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,3 +80,5 @@ export enum ColonyActionType {
   EmitDomainReputationPenalty = 'EMIT_DOMAIN_REPUTATION_PENALTY',
   EmitDomainReputationReward = 'EMIT_DOMAIN_REPUTATION_REWARD',
 }
+
+export type ColonyActionHandler = (event: ContractEvent) => Promise<void>;

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -9,7 +9,7 @@ import {
 } from '@colony/colony-js';
 
 import networkClient from '~networkClient';
-import { ContractEvent, ContractEventsSignatures } from '~types';
+import { ContractEvent, ContractEventsSignatures, Filter } from '~types';
 import { addEvent } from '~eventQueue';
 import { mutate, query } from '~amplifyClient';
 import { getChainId } from '~provider';
@@ -42,13 +42,13 @@ export const eventListenerGenerator = async (
     client = await getCachedColonyClient(contractAddress);
   }
 
-  const filter: { topics: Array<string | null>; address?: string } = {
+  const filter: Filter = {
     topics: [utils.id(eventSignature)],
   };
 
   if (clientType === ClientType.TokenClient) {
     filter.topics = [
-      ...filter.topics,
+      ...(filter.topics ?? []),
       null,
       utils.hexZeroPad(contractAddress, 32),
     ];


### PR DESCRIPTION
This PR adds tracking of past actions that might have happened when block-ingestor was down.

Similarly to extensions tracking, it currently goes through all events since block number 1 and I opened an issue to change it in the future: #39 

## Testing
Testing involves triggering all the supported actions while block-ingestor is disabled (so you need to start the CDapp on `master` without it running), then running the ingestor separately and verifying that the actions have been picked up and written to the database.