### PR TITLE
Add NetworkFeeInverseSet event handler

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -45,9 +45,9 @@ export const mutations = {
       setCurrentVersion(input: $input)
     }
   `,
-  setCurrentInverseFee: /* GraphQL */ `
-    mutation SetCurrentInverseFee($input: SetCurrentInverseFeeInput!) {
-      setCurrentInverseFee(input: $input)
+  setCurrentNetworkInverseFee: /* GraphQL */ `
+    mutation setCurrentNetworkInverseFee($input: setCurrentNetworkInverseFeeInput!) {
+      setCurrentNetworkInverseFee(input: $input)
     }
   `,
   createColonyExtension: /* GraphQL */ `

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -45,9 +45,18 @@ export const mutations = {
       setCurrentVersion(input: $input)
     }
   `,
-  setCurrentNetworkInverseFee: /* GraphQL */ `
-    mutation setCurrentNetworkInverseFee($input: SetCurrentNetworkInverseFeeInput!) {
-      setCurrentNetworkInverseFee(input: $input)
+  createCurrentNetworkInverseFee: /* GraphQL */ `
+    mutation CreateCurrentNetworkInverseFee($input: CreateCurrentNetworkInverseFeeInput!) {
+      createCurrentNetworkInverseFee(input: $input) {
+        id
+      }
+    }
+  `,
+  updateCurrentNetworkInverseFee: /* GraphQL */ `
+    mutation UpdateCurrentNetworkInverseFee($input: UpdateCurrentNetworkInverseFeeInput!) {
+      updateCurrentNetworkInverseFee(input: $input) {
+        id
+      }
     }
   `,
   createColonyExtension: /* GraphQL */ `
@@ -139,6 +148,16 @@ export const queries = {
     query GetContractEvent($id: ID!) {
       getContractEvent(id: $id) {
         id
+      }
+    }
+  `,
+  getCurrentNetworkInverseFee: /* GraphQL */ `
+    query GetCurrentNetworkInverseFee {
+      listCurrentNetworkInverseFees(limit: 1) {
+        items {
+          id
+          inverseFee
+        }
       }
     }
   `,

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -46,7 +46,7 @@ export const mutations = {
     }
   `,
   setCurrentNetworkInverseFee: /* GraphQL */ `
-    mutation setCurrentNetworkInverseFee($input: setCurrentNetworkInverseFeeInput!) {
+    mutation setCurrentNetworkInverseFee($input: SetCurrentNetworkInverseFeeInput!) {
       setCurrentNetworkInverseFee(input: $input)
     }
   `,

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -45,6 +45,11 @@ export const mutations = {
       setCurrentVersion(input: $input)
     }
   `,
+  setCurrentInverseFee: /* GraphQL */ `
+    mutation SetCurrentInverseFee($input: SetCurrentInverseFeeInput!) {
+      setCurrentInverseFee(input: $input)
+    }
+  `,
   createColonyExtension: /* GraphQL */ `
     mutation CreateColonyExtension($input: CreateColonyExtensionInput!) {
       createColonyExtension(input: $input) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ import { Extension } from '@colony/colony-js';
 
 export const COLONY_CURRENT_VERSION_KEY = 'colony';
 
+export const NETWORK_INVERSE_FEE_DATABASE_ID = 'networkInverseFee';
+
 export const SUPPORTED_EXTENSION_IDS = [
   Extension.OneTxPayment,
   Extension.VotingReputation,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,5 @@ export const SUPPORTED_EXTENSION_IDS = [
   Extension.VotingReputation,
 ];
 export const INITIALISABLE_EXTENSION_IDS = [Extension.VotingReputation];
+
+export const NETWORK_INVERSE_FEE_KEY = 'networkInverseFee';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,5 +7,3 @@ export const SUPPORTED_EXTENSION_IDS = [
   Extension.VotingReputation,
 ];
 export const INITIALISABLE_EXTENSION_IDS = [Extension.VotingReputation];
-
-export const NETWORK_INVERSE_FEE_KEY = 'networkInverseFee';

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -54,6 +54,8 @@ const eventListener = async (): Promise<void> => {
   await addNetworkEventListener(ContractEventsSignatures.ExtensionUpgraded);
 
   await addNetworkEventListener(ContractEventsSignatures.ColonyVersionAdded);
+
+  await addNetworkEventListener(ContractEventsSignatures.NetworkFeeInverseSet);
 };
 
 export default eventListener;

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -54,7 +54,6 @@ const eventListener = async (): Promise<void> => {
   await addNetworkEventListener(ContractEventsSignatures.ExtensionUpgraded);
 
   await addNetworkEventListener(ContractEventsSignatures.ColonyVersionAdded);
-  await addNetworkEventListener(ContractEventsSignatures.NetworkFeeInverseSet);
 };
 
 export default eventListener;

--- a/src/eventListener.ts
+++ b/src/eventListener.ts
@@ -54,6 +54,7 @@ const eventListener = async (): Promise<void> => {
   await addNetworkEventListener(ContractEventsSignatures.ExtensionUpgraded);
 
   await addNetworkEventListener(ContractEventsSignatures.ColonyVersionAdded);
+  await addNetworkEventListener(ContractEventsSignatures.NetworkFeeInverseSet);
 };
 
 export default eventListener;

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -21,6 +21,7 @@ import {
   handleEditColonyAction,
   handleVersionUpgradeAction,
   handleEmitDomainReputationAction,
+  handleNetworkFeeInverseSet,
 } from './handlers';
 
 dotenv.config();
@@ -74,6 +75,11 @@ export default async (event: ContractEvent): Promise<void> => {
      */
     case ContractEventsSignatures.ColonyVersionAdded: {
       await handleColonyVersionAdded(event);
+      return;
+    }
+
+    case ContractEventsSignatures.NetworkFeeInverseSet: {
+      await handleNetworkFeeInverseSet(event);
       return;
     }
 

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,3 +1,4 @@
 export * from './colonies';
 export * from './actions';
 export * from './extensions';
+export * from './network';

--- a/src/handlers/network/index.ts
+++ b/src/handlers/network/index.ts
@@ -1,0 +1,1 @@
+export { default as handleNetworkFeeInverseSet } from './networkFeeInverseSet';

--- a/src/handlers/network/networkFeeInverseSet.ts
+++ b/src/handlers/network/networkFeeInverseSet.ts
@@ -1,4 +1,5 @@
-import { mutate, query } from '~amplifyClient';
+import { mutate } from '~amplifyClient';
+import { NETWORK_INVERSE_FEE_DATABASE_ID } from '~constants';
 import { ContractEvent } from '~types';
 import { output } from '~utils';
 
@@ -6,32 +7,15 @@ export default async (event: ContractEvent): Promise<void> => {
   const { feeInverse } = event.args;
   const convertedFee = feeInverse.toString();
 
-  const { items: networkInverseFees } = await query(
-    'getCurrentNetworkInverseFee',
+  await mutate(
+      'updateCurrentNetworkInverseFee',
+    {
+      input: {
+        id: NETWORK_INVERSE_FEE_DATABASE_ID,
+        inverseFee: convertedFee,
+      },
+    },
   );
-
-  const hasExistingNetworkInverseFee = !!networkInverseFees?.length;
-
-  if (hasExistingNetworkInverseFee) {
-    await mutate(
-        'updateCurrentNetworkInverseFee',
-      {
-        input: {
-          id: networkInverseFees[0].id,
-          inverseFee: convertedFee,
-        },
-      },
-    );
-  } else {
-    await mutate(
-      'createCurrentNetworkInverseFee',
-      {
-        input: {
-          inverseFee: convertedFee,
-        },
-      },
-    );    
-  }
 
   output('New network inverse fee:', convertedFee);
 };

--- a/src/handlers/network/networkFeeInverseSet.ts
+++ b/src/handlers/network/networkFeeInverseSet.ts
@@ -4,7 +4,7 @@ import { toNumber, verbose } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { feeInverse } = event.args;
-  const convertedFee = toNumber(feeInverse);
+  const convertedFee = feeInverse.toString();
 
   verbose('New network inverse fee:', convertedFee);
 

--- a/src/handlers/network/networkFeeInverseSet.ts
+++ b/src/handlers/network/networkFeeInverseSet.ts
@@ -1,5 +1,4 @@
 import { mutate } from '~amplifyClient';
-import { NETWORK_INVERSE_FEE_KEY } from '~constants';
 import { ContractEvent } from '~types';
 import { toNumber, verbose } from '~utils';
 
@@ -9,9 +8,8 @@ export default async (event: ContractEvent): Promise<void> => {
 
   verbose('New network inverse fee:', convertedFee);
 
-  await mutate('setCurrentInverseFee', {
+  await mutate('setCurrentNetworkInverseFee', {
     input: {
-      key: NETWORK_INVERSE_FEE_KEY,
       inverseFee: convertedFee,
     },
   });

--- a/src/handlers/network/networkFeeInverseSet.ts
+++ b/src/handlers/network/networkFeeInverseSet.ts
@@ -18,7 +18,7 @@ export default async (event: ContractEvent): Promise<void> => {
       {
         input: {
           id: networkInverseFees[0].id,
-          convertedFee,
+          inverseFee: convertedFee,
         },
       },
     );
@@ -27,7 +27,7 @@ export default async (event: ContractEvent): Promise<void> => {
       'createCurrentNetworkInverseFee',
       {
         input: {
-          convertedFee,
+          inverseFee: convertedFee,
         },
       },
     );    

--- a/src/handlers/network/networkFeeInverseSet.ts
+++ b/src/handlers/network/networkFeeInverseSet.ts
@@ -1,16 +1,37 @@
-import { mutate } from '~amplifyClient';
+import { mutate, query } from '~amplifyClient';
 import { ContractEvent } from '~types';
-import { toNumber, verbose } from '~utils';
+import { output } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { feeInverse } = event.args;
   const convertedFee = feeInverse.toString();
 
-  verbose('New network inverse fee:', convertedFee);
+  const { items: networkInverseFees } = await query(
+    'getCurrentNetworkInverseFee',
+  );
 
-  await mutate('setCurrentNetworkInverseFee', {
-    input: {
-      inverseFee: convertedFee,
-    },
-  });
+  const hasExistingNetworkInverseFee = !!networkInverseFees?.length;
+
+  if (hasExistingNetworkInverseFee) {
+    await mutate(
+        'updateCurrentNetworkInverseFee',
+      {
+        input: {
+          id: networkInverseFees[0].id,
+          convertedFee,
+        },
+      },
+    );
+  } else {
+    await mutate(
+      'createCurrentNetworkInverseFee',
+      {
+        input: {
+          convertedFee,
+        },
+      },
+    );    
+  }
+
+  output('New network inverse fee:', convertedFee);
 };

--- a/src/handlers/network/networkFeeInverseSet.ts
+++ b/src/handlers/network/networkFeeInverseSet.ts
@@ -1,0 +1,18 @@
+import { mutate } from '~amplifyClient';
+import { NETWORK_INVERSE_FEE_KEY } from '~constants';
+import { ContractEvent } from '~types';
+import { toNumber, verbose } from '~utils';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { feeInverse } = event.args;
+  const convertedFee = toNumber(feeInverse);
+
+  verbose('New network inverse fee:', convertedFee);
+
+  await mutate('setCurrentInverseFee', {
+    input: {
+      key: NETWORK_INVERSE_FEE_KEY,
+      inverseFee: convertedFee,
+    },
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import amplifyClientSetup from './amplifyClient';
 import provider, { getChainId } from './provider';
 import { output, readJsonStats } from './utils';
 import trackExtensions from './trackExtensions';
+import trackNetworkInverseFee from './trackNetworkInverseFee';
 
 dotenv.config();
 utils.Logger.setLogLevel(utils.Logger.levels.ERROR);
@@ -57,6 +58,11 @@ const startIngestor = async (): Promise<void> => {
    * Get all supported extensions currently installed in colonies
    */
   await trackExtensions();
+
+  /*
+   * Get initial network inverse fee and setup listener for future ones
+   */
+  await trackNetworkInverseFee();
 
   /*
    * Setup all listeners we care about

--- a/src/trackNetworkInverseFee.ts
+++ b/src/trackNetworkInverseFee.ts
@@ -8,6 +8,7 @@ import {
 } from './utils';
 import { ContractEventsSignatures } from './types';
 import { mutate } from './amplifyClient';
+import { NETWORK_INVERSE_FEE_DATABASE_ID } from '~constants';
 
 dotenv.config();
 
@@ -19,6 +20,7 @@ export default async (): Promise<void> => {
 
   await mutate('createCurrentNetworkInverseFee', {
     input: {
+      id: NETWORK_INVERSE_FEE_DATABASE_ID,
       inverseFee: convertedFee,
     },
   });

--- a/src/trackNetworkInverseFee.ts
+++ b/src/trackNetworkInverseFee.ts
@@ -17,16 +17,11 @@ export default async (): Promise<void> => {
   const networkInverseFee = await networkClient.getFeeInverse();
   const convertedFee = networkInverseFee.toString();
 
-  await mutate('setCurrentNetworkInverseFee', {
+  await mutate('createCurrentNetworkInverseFee', {
     input: {
       inverseFee: convertedFee,
     },
   });
 
   output('Current network inverse fee is: ', convertedFee);
-
-  /*
-   * Set a Network level listener to track new inverse fees
-   */
-  await addNetworkEventListener(ContractEventsSignatures.NetworkFeeInverseSet);
 };

--- a/src/trackNetworkInverseFee.ts
+++ b/src/trackNetworkInverseFee.ts
@@ -1,0 +1,32 @@
+import dotenv from 'dotenv';
+
+import networkClient from './networkClient';
+import {
+  output,
+  verbose,
+  addNetworkEventListener,
+} from './utils';
+import { ContractEventsSignatures } from './types';
+import { mutate } from './amplifyClient';
+
+dotenv.config();
+
+export default async (): Promise<void> => {
+  verbose('Fetching current network inverse fee');
+
+  const networkInverseFee = await networkClient.getFeeInverse();
+  const convertedFee = networkInverseFee.toString();
+
+  await mutate('setCurrentNetworkInverseFee', {
+    input: {
+      inverseFee: convertedFee,
+    },
+  });
+
+  output('Current network inverse fee is: ', convertedFee);
+
+  /*
+   * Set a Network level listener to track new inverse fees
+   */
+  await addNetworkEventListener(ContractEventsSignatures.NetworkFeeInverseSet);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export enum ContractEventsSignatures {
   ColonyFundsClaimed = 'ColonyFundsClaimed(address,address,uint256,uint256)',
   ColonyVersionAdded = 'ColonyVersionAdded(uint256,address)',
   ColonyUpgraded = 'ColonyUpgraded(address,uint256,uint256)',
+  NetworkFeeInverseSet = 'NetworkFeeInverseSet(uint256)',
 
   // Extensions
   ExtensionAddedToNetwork = 'ExtensionAddedToNetwork(bytes32,uint256)',


### PR DESCRIPTION
This PR adds support for the `NetworkFeeInverseSet` event emitted every time the inverse fee is updated by Network.

Let me know if the logic or flow sounds good to you guys. This is my first time implementing something in the `block-ingestor` and I tried to take existing code as an example for this.

Corresponds with https://github.com/JoinColony/colonyCDapp/pull/325

