### PR TITLE
Make unique database motion id

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -155,6 +155,7 @@ export const queries = {
           id
           motionData {
             motionId
+            nativeMotionId
             motionStakes {
               raw {
                 nay
@@ -189,10 +190,11 @@ export const queries = {
                 yay
                 nay
               }
+              isClaimed
             }
             isFinalized
+            createdBy
           }
-          createdAt
         }
       }
     }

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -20,12 +20,11 @@ export const updateMotionInDB = async (
   });
 };
 
-/*
- * Motion ids are not unique between voting reputation installations. If you had a motion with id of 1
- * in a previous voting reputation installation, you will get another one after uninstalling and reinstalling
- * the voting reputation client. So, we only want the one created most recently, since that's the one created
- * by the currently installed version of the voting reputation extension.
- */
+export const getMotionDatabaseId = (
+  chainId: number,
+  votingRepExtnAddress: string,
+  nativeMotionId: BigNumber,
+): string => `${chainId}-${votingRepExtnAddress}_${nativeMotionId}`;
 
 export const getMotionFromDB = async (
   colonyAddress: string,

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -29,7 +29,7 @@ export const updateMotionInDB = async (
 
 export const getMotionFromDB = async (
   colonyAddress: string,
-  motionId: BigNumber,
+  databaseMotionId: string,
 ): Promise<MotionQuery | undefined> => {
   const { items: motions } =
     (await query<{ items: MotionQuery[] }>('getColonyMotions', {
@@ -44,18 +44,9 @@ export const getMotionFromDB = async (
     return undefined;
   }
 
-  const motionsWithCorrectId = motions.filter(
-    ({ motionData: { motionId: id } }) => id === motionId.toString(),
+  const motion = motions.find(
+    ({ motionData: { motionId } }) => motionId === databaseMotionId,
   );
-
-  if (motionsWithCorrectId.length > 1) {
-    motionsWithCorrectId.sort(
-      (a, b) =>
-        new Date(a.createdAt).valueOf() - new Date(b.createdAt).valueOf(),
-    );
-  }
-
-  const motion = motionsWithCorrectId.pop();
 
   if (!motion) {
     verbose(

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -11,7 +11,11 @@ import {
   verbose,
 } from '~utils';
 
-import { getRequiredStake, getUserMinStake } from '../helpers';
+import {
+  getMotionDatabaseId,
+  getRequiredStake,
+  getUserMinStake,
+} from '../helpers';
 export const getParsedActionFromMotion = async (
   motionId: string,
   colonyClient: AnyColonyClient,
@@ -31,12 +35,6 @@ export const getParsedActionFromMotion = async (
     return undefined;
   }
 };
-
-export const getMotionDatabaseId = (
-  chainId: number,
-  votingRepExtnAddress: string,
-  nativeMotionId: BigNumber,
-): string => `${chainId}-${votingRepExtnAddress}_${nativeMotionId}`;
 
 const getMotionData = async (
   colonyAddress: string,

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -12,7 +12,6 @@ import {
 } from '~utils';
 
 import { getRequiredStake, getUserMinStake } from '../helpers';
-
 export const getParsedActionFromMotion = async (
   motionId: string,
   colonyClient: AnyColonyClient,
@@ -32,6 +31,12 @@ export const getParsedActionFromMotion = async (
     return undefined;
   }
 };
+
+export const getMotionDatabaseId = (
+  chainId: number,
+  votingRepExtnAddress: string,
+  nativeMotionId: BigNumber,
+): string => `${chainId}-${votingRepExtnAddress}_${nativeMotionId}`;
 
 const getMotionData = async (
   colonyAddress: string,
@@ -53,8 +58,12 @@ const getMotionData = async (
     skillRep,
   );
 
+  const { chainId } = await votingClient.provider.getNetwork();
+
   return {
-    motionId: motionId.toString(),
+    createdBy: votingClient.address,
+    motionId: getMotionDatabaseId(chainId, votingClient.address, motionId),
+    nativeMotionId: motionId.toString(),
     motionStakes: {
       raw: {
         nay: '0',

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,6 +1,10 @@
 import { ContractEvent } from '~types';
-import { getMotionDatabaseId, getVotingClient } from '~utils';
-import { getMotionFromDB, updateMotionInDB } from '../helpers';
+import { getVotingClient } from '~utils';
+import {
+  getMotionDatabaseId,
+  getMotionFromDB,
+  updateMotionInDB,
+} from '../helpers';
 import { getStakerReward } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,4 +1,5 @@
 import { ContractEvent } from '~types';
+import { getMotionDatabaseId, getVotingClient } from '~utils';
 import { getMotionFromDB, updateMotionInDB } from '../helpers';
 import { getStakerReward } from './helpers';
 
@@ -8,7 +9,17 @@ export default async (event: ContractEvent): Promise<void> => {
     args: { motionId },
   } = event;
 
-  const finalizedMotion = await getMotionFromDB(colonyAddress, motionId);
+  const votingClient = await getVotingClient(colonyAddress);
+  const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
+  const finalizedMotion = await getMotionFromDB(
+    colonyAddress,
+    motionDatabaseId,
+  );
   if (finalizedMotion) {
     const {
       motionData: { usersStakes },

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -1,6 +1,10 @@
 import { ContractEvent, MotionData } from '~types';
-import { getMotionDatabaseId, getVotingClient } from '~utils';
-import { getMotionFromDB, updateMotionInDB } from './helpers';
+import { getVotingClient } from '~utils';
+import {
+  getMotionDatabaseId,
+  getMotionFromDB,
+  updateMotionInDB,
+} from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -1,4 +1,5 @@
 import { ContractEvent, MotionData } from '~types';
+import { getMotionDatabaseId, getVotingClient } from '~utils';
 import { getMotionFromDB, updateMotionInDB } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
@@ -7,7 +8,14 @@ export default async (event: ContractEvent): Promise<void> => {
     args: { motionId, staker },
   } = event;
 
-  const claimedMotion = await getMotionFromDB(colonyAddress, motionId);
+  const votingClient = await getVotingClient(colonyAddress);
+  const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
+  const claimedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
 
   if (claimedMotion) {
     const {

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,6 +1,7 @@
 import { ContractEvent } from '~types';
-import { verbose, getVotingClient, getMotionDatabaseId } from '~utils';
+import { verbose, getVotingClient } from '~utils';
 import {
+  getMotionDatabaseId,
   getMotionFromDB,
   getMotionSide,
   getMotionStakes,

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -1,5 +1,5 @@
 import { ContractEvent } from '~types';
-import { verbose, getVotingClient } from '~utils';
+import { verbose, getVotingClient, getMotionDatabaseId } from '~utils';
 import {
   getMotionFromDB,
   getMotionSide,
@@ -24,7 +24,13 @@ export default async (event: ContractEvent): Promise<void> => {
   const motionStakes = getMotionStakes(requiredStake, stakes);
   const remainingStakes = getRemainingStakes(requiredStake, stakes);
 
-  const stakedMotion = await getMotionFromDB(colonyAddress, motionId);
+  const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
+  const stakedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
 
   if (stakedMotion) {
     const {

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -43,6 +43,7 @@ export interface MotionStakes {
 
 export interface MotionData {
   motionId: string;
+  nativeMotionId: string;
   usersStakes: UserStakes[];
   motionStakes: MotionStakes;
   remainingStakes: [string, string];
@@ -53,6 +54,7 @@ export interface MotionData {
   motionDomainId: string;
   stakerRewards: StakerReward[];
   isFinalized: boolean;
+  createdBy: string;
 }
 
 export interface UserStakes {


### PR DESCRIPTION
This pr updates the relevant motion handlers to fetch the motion from the db using the unique database id, as opposed to using the native id and sorting by created date.