### PR TITLE
Add actions list support

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -216,6 +216,23 @@ export const queries = {
       }
     }
   `,
+  getVotingRepInstallations: /* GraphQL */ `
+    query GetVotingRepInstallations(
+      $votingRepHash: String!
+      $colonyAddress: ID!
+    ) {
+      listColonyExtensions(
+        filter: {
+          hash: { eq: $votingRepHash }
+          colonyId: { eq: $colonyAddress }
+        }
+      ) {
+        items {
+          id
+        }
+      }
+    }
+  `,
 };
 
 export default (): void => {

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -221,11 +221,9 @@ export const queries = {
       $votingRepHash: String!
       $colonyAddress: ID!
     ) {
-      listColonyExtensions(
-        filter: {
-          hash: { eq: $votingRepHash }
-          colonyId: { eq: $colonyAddress }
-        }
+      getExtensionByColonyAndHash(
+        colonyId: $colonyAddress
+        hash: { eq: $votingRepHash }
       ) {
         items {
           id

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -11,11 +11,13 @@ export const getMotionSide = (vote: BigNumber): MotionSide =>
 export const updateMotionInDB = async (
   id: string,
   motionData: MotionData,
+  showInActionsList?: boolean,
 ): Promise<void> => {
   await mutate('updateColonyAction', {
     input: {
       id,
       motionData,
+      ...(showInActionsList === undefined ? {} : { showInActionsList }),
     },
   });
 };

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -22,6 +22,18 @@ export const updateMotionInDB = async (
   });
 };
 
+export const createMotionInDB = async (
+  input: Record<string, any>,
+): Promise<void> => {
+  await mutate('createColonyAction', {
+    input: {
+      isMotion: true,
+      showInActionsList: false,
+      ...input,
+    },
+  });
+};
+
 export const getMotionDatabaseId = (
   chainId: number,
   votingRepExtnAddress: string,

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -2,7 +2,6 @@ import { AnyColonyClient, Extension } from '@colony/colony-js';
 import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 
-import { mutate } from '~amplifyClient';
 import { MotionData, ContractEvent, motionNameMapping } from '~types';
 import {
   getColonyTokenAddress,
@@ -12,6 +11,7 @@ import {
 } from '~utils';
 
 import {
+  createMotionInDB,
   getMotionDatabaseId,
   getRequiredStake,
   getUserMinStake,
@@ -112,18 +112,15 @@ export const writeMintTokensMotionToDB = async (
   const amount = actionArgs[0].toString();
   const tokenAddress = await getColonyTokenAddress(colonyAddress);
   const motionData = await getMotionData(colonyAddress, motionId, domainId);
-  await mutate('createColonyAction', {
-    input: {
-      id: transactionHash,
-      colonyId: colonyAddress,
-      type: motionNameMapping[name],
-      isMotion: true,
-      motionData,
-      tokenAddress,
-      fromDomainId: getDomainDatabaseId(colonyAddress, domainId),
-      initiatorAddress: creator,
-      amount,
-      blockNumber,
-    },
+  await createMotionInDB({
+    id: transactionHash,
+    colonyId: colonyAddress,
+    type: motionNameMapping[name],
+    motionData,
+    tokenAddress,
+    fromDomainId: getDomainDatabaseId(colonyAddress, domainId),
+    initiatorAddress: creator,
+    amount,
+    blockNumber,
   });
 };

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -24,7 +24,9 @@ export default async (event: ContractEvent): Promise<void> => {
   const requiredStake = getRequiredStake(skillRep, totalStakeFraction);
   const motionStakes = getMotionStakes(requiredStake, stakes);
   const remainingStakes = getRemainingStakes(requiredStake, stakes);
-
+  const showInActionsList =
+    Number(motionStakes.percentage.yay) + Number(motionStakes.percentage.nay) >=
+    10;
   const { chainId } = await votingClient.provider.getNetwork();
   const motionDatabaseId = getMotionDatabaseId(
     chainId,
@@ -48,12 +50,16 @@ export default async (event: ContractEvent): Promise<void> => {
       requiredStake,
     );
 
-    await updateMotionInDB(id, {
-      ...motionData,
-      usersStakes: updatedUserStakes,
-      motionStakes,
-      remainingStakes,
-    });
+    await updateMotionInDB(
+      id,
+      {
+        ...motionData,
+        usersStakes: updatedUserStakes,
+        motionStakes,
+        remainingStakes,
+      },
+      showInActionsList,
+    );
 
     verbose(
       `User: ${staker} staked motion ${motionId.toString()} by ${amount.toString()} on side ${getMotionSide(

--- a/src/utils/actions/writeAction.ts
+++ b/src/utils/actions/writeAction.ts
@@ -18,6 +18,7 @@ export const writeActionFromEvent = async (
       colonyId: colonyAddress,
       blockNumber,
       createdAt: new Date(timestamp * 1000).toISOString(),
+      showInActionsList: true,
       ...actionFields,
     },
   });

--- a/src/utils/actions/writeAction.ts
+++ b/src/utils/actions/writeAction.ts
@@ -1,25 +1,65 @@
-import { mutate } from '~amplifyClient';
-import { ContractEvent } from '~types';
+import { Extension, getExtensionHash } from '@colony/colony-js';
+import { mutate, query } from '~amplifyClient';
+import { ColonyActionType, ContractEvent } from '~types';
 import { verbose } from '~utils';
+
+interface ActionFields extends Record<string, any> {
+  initiatorAddress: string;
+  type: ColonyActionType;
+}
 
 export const writeActionFromEvent = async (
   event: ContractEvent,
   colonyAddress: string,
-  actionFields: Record<string, any>,
+  actionFields: ActionFields,
 ): Promise<void> => {
   const { transactionHash, blockNumber, timestamp } = event;
 
   const actionType = actionFields.type ?? 'UNKNOWN';
-  verbose('Action', actionType, 'took place in Colony:', colonyAddress);
+  const showInActionsList = await showActionInActionsList(
+    colonyAddress,
+    actionFields.initiatorAddress,
+  );
 
+  verbose('Action', actionType, 'took place in Colony:', colonyAddress);
   await mutate('createColonyAction', {
     input: {
       id: transactionHash,
       colonyId: colonyAddress,
       blockNumber,
       createdAt: new Date(timestamp * 1000).toISOString(),
-      showInActionsList: true,
+      showInActionsList,
       ...actionFields,
     },
   });
+};
+
+const getVotingReputationInstallations = async (
+  colonyAddress: string,
+): Promise<Array<{ id: string }> | undefined> => {
+  const votingRepHash = getExtensionHash(Extension.VotingReputation);
+  const { items } =
+    (await query<{ items: Array<{ id: string }> }>(
+      'getVotingRepInstallations',
+      {
+        votingRepHash,
+        colonyAddress,
+      },
+    )) ?? {};
+
+  return items;
+};
+
+const showActionInActionsList = async (
+  colonyAddress: string,
+  initiatorAddress: string,
+): Promise<boolean> => {
+  const votingRepIds = await getVotingReputationInstallations(colonyAddress);
+
+  if (!votingRepIds) {
+    return true;
+  }
+
+  // If the action was created by a motion, don't show it in the list
+  return !votingRepIds.some(({ id }) => id === initiatorAddress);
 };


### PR DESCRIPTION
This PR adds a flag to actions and motions indicating whether they should appear in the actions list. Test with https://github.com/JoinColony/colonyCDapp/pull/410

It's:

- true for actions that were not initiated by a voting rep extn
- true for motions if total stake >= 10 %
- else false

