### PR TITLE
Add support for pending domain metadata on finalized motions

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -99,6 +99,20 @@ export const mutations = {
       }
     }
   `,
+  createDomainMetadata: /* GraphQL */ `
+    mutation CreateDomainMetadata($input: CreateDomainMetadataInput!) {
+      createDomainMetadata(input: $input) {
+        id
+      }
+    }
+  `,
+  updateDomainMetadata: /* GraphQL */ `
+    mutation UpdateDomainMetadata($input: UpdateDomainMetadataInput!) {
+      updateDomainMetadata(input: $input) {
+        id
+      }
+    }
+  `,
 };
 
 /*
@@ -218,6 +232,20 @@ export const queries = {
               initiatorAddress
               vote
               amount
+            }
+          }
+          pendingDomainMetadata {
+            name
+            color
+            description
+            changelog {
+              transactionHash
+              oldName
+              newName
+              oldColor
+              newColor
+              oldDescription
+              newDescription
             }
           }
         }

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -53,8 +53,8 @@ export const getStakerReward = async (
   };
 };
 
-export const getParsedActionFromMotion = async (
-  motionAction: string,
+const getParsedActionFromDomainMotion = async (
+  domainAction: string,
   colonyAddress: string,
 ): Promise<TransactionDescription | undefined> => {
   const colonyClient = await networkClient.getColonyClient(colonyAddress);
@@ -62,16 +62,16 @@ export const getParsedActionFromMotion = async (
   // We are only parsing this action in order to know if it's a add/edit domain motion. Therefore, we shouldn't need to try with any other client.
   try {
     return colonyClient.interface.parseTransaction({
-      data: motionAction,
-    });    
+      data: domainAction,
+    });
   } catch {
-    verbose(`Unable to parse ${motionAction} using colony client`);
+    verbose(`Unable to parse ${domainAction} using colony client`);
     return undefined;
   }
 };
 
-export const linkPendingDomainMetadataWithDomain = async (action: string, colonyAddress: string, finalizedMotion: MotionQuery) => {
-  const parsedDomainAction = await getParsedActionFromMotion(action, colonyAddress);
+export const linkPendingDomainMetadataWithDomain = async (action: string, colonyAddress: string, finalizedMotion: MotionQuery): Promise<void> => {
+  const parsedDomainAction = await getParsedActionFromDomainMotion(action, colonyAddress);
   if (parsedDomainAction?.name === ColonyOperations.AddDomain) {
     const colonyClient = await networkClient.getColonyClient(colonyAddress);
     const domainCount = await colonyClient.getDomainCount();
@@ -83,9 +83,8 @@ export const linkPendingDomainMetadataWithDomain = async (action: string, colony
       input: {
         ...finalizedMotion.pendingDomainMetadata,
         id: getDomainDatabaseId(colonyAddress, nativeDomainId),
-        
       },
-    });        
+    });
   } else if (parsedDomainAction?.name === ColonyOperations.EditDomain) {
     const nativeDomainId = parsedDomainAction.args[2].toNumber(); // domainId arg from editDomain action
 
@@ -94,6 +93,6 @@ export const linkPendingDomainMetadataWithDomain = async (action: string, colony
         ...finalizedMotion.pendingDomainMetadata,
         id: getDomainDatabaseId(colonyAddress, nativeDomainId),
       },
-    }); 
+    });
   }
 };

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -1,7 +1,9 @@
 import { BigNumber } from 'ethers';
+import { TransactionDescription } from 'ethers/lib/utils';
 
 import { MotionVote, StakerReward } from '~types';
-import { getVotingClient } from '~utils';
+import { getVotingClient, verbose } from '~utils';
+import networkClient from '~networkClient';
 
 export const getStakerReward = async (
   motionId: string,
@@ -48,4 +50,21 @@ export const getStakerReward = async (
     },
     isClaimed: false,
   };
+};
+
+export const getParsedActionFromMotion = async (
+  motionAction: string,
+  colonyAddress: string,
+): Promise<TransactionDescription | undefined> => {
+  const colonyClient = await networkClient.getColonyClient(colonyAddress);
+
+  // We are only parsing this action in order to know if it's a add/edit domain motion. Therefore, we shouldn't need to try with any other client.
+  try {
+    return colonyClient.interface.parseTransaction({
+      data: motionAction,
+    });    
+  } catch {
+    verbose(`Unable to parse ${motionAction} using colony client`);
+    return undefined;
+  }
 };

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,16 +1,20 @@
-import { ContractEvent } from '~types';
-import { getVotingClient } from '~utils';
+import { ColonyOperations, ContractEvent } from '~types';
+import { getDomainDatabaseId, getVotingClient } from '~utils';
+import { mutate } from '~amplifyClient';
+import networkClient from '~networkClient';
+
 import {
   getMotionDatabaseId,
   getMotionFromDB,
   updateMotionInDB,
 } from '../helpers';
-import { getStakerReward } from './helpers';
+
+import { getParsedActionFromMotion, getStakerReward } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
     contractAddress: colonyAddress,
-    args: { motionId },
+    args: { motionId, action },
   } = event;
 
   const votingClient = await getVotingClient(colonyAddress);
@@ -29,6 +33,32 @@ export default async (event: ContractEvent): Promise<void> => {
       motionData: { usersStakes },
       motionData,
     } = finalizedMotion;
+
+    if (finalizedMotion.pendingDomainMetadata) {
+      const parsedDomainAction = await getParsedActionFromMotion(action, colonyAddress);
+      if (parsedDomainAction?.name === ColonyOperations.AddDomain) {
+        const colonyClient = await networkClient.getColonyClient(colonyAddress);
+        const domainCount = await colonyClient.getDomainCount();
+        const nativeDomainId = domainCount.add(1).toNumber();
+
+        await mutate('createDomainMetadata', {
+          input: {
+            ...finalizedMotion.pendingDomainMetadata,
+            id: getDomainDatabaseId(colonyAddress, nativeDomainId),
+            
+          },
+        });        
+      } else if (parsedDomainAction?.name === ColonyOperations.EditDomain) {
+        const nativeDomainId = parsedDomainAction.args[2].toNumber();
+
+        await mutate('updateDomainMetadata', {
+          input: {
+            ...finalizedMotion.pendingDomainMetadata,
+            id: getDomainDatabaseId(colonyAddress, nativeDomainId),
+          },
+        }); 
+      }
+    }
 
     const updatedStakerRewards = await Promise.all(
       usersStakes.map(

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -37,9 +37,12 @@ export default async (event: ContractEvent): Promise<void> => {
     const {
       revealedVotes: {
         raw: { yay: yayVotes, nay: nayVotes },
-      }
+      },
+      motionStakes: {
+        percentage: { yay: yayPercentage, nay: nayPercentage },
+      },
     } = motionData;
-    const yayWon = BigNumber.from(yayVotes).gt(nayVotes);
+    const yayWon = BigNumber.from(yayVotes).gt(nayVotes) || (Number(yayPercentage) > Number(nayPercentage));
 
     if (finalizedMotion.pendingDomainMetadata && yayWon) {
       await linkPendingDomainMetadataWithDomain(action, colonyAddress, finalizedMotion);

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -8,7 +8,6 @@ import {
   getMotionFromDB,
   updateMotionInDB,
 } from '../helpers';
-
 import { getStakerReward, linkPendingDomainMetadataWithDomain } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
@@ -30,20 +29,26 @@ export default async (event: ContractEvent): Promise<void> => {
   );
   if (finalizedMotion) {
     const {
-      motionData: { usersStakes },
+      motionData: {
+        usersStakes,
+        revealedVotes: {
+          raw: { yay: yayVotes, nay: nayVotes },
+        },
+        motionStakes: {
+          percentage: { yay: yayPercentage, nay: nayPercentage },
+        },
+      },
       motionData,
     } = finalizedMotion;
 
-    const {
-      revealedVotes: {
-        raw: { yay: yayVotes, nay: nayVotes },
-      },
-      motionStakes: {
-        percentage: { yay: yayPercentage, nay: nayPercentage },
-      },
-    } = motionData;
     const yayWon = BigNumber.from(yayVotes).gt(nayVotes) || (Number(yayPercentage) > Number(nayPercentage));
 
+    /*
+     * pendingDomainMetadata is a motion data prop that we use to store the metadata of a Domain that COULD be created/edited
+     * if the YAY side of the motion won and the motion was finalized. In this step, if the motion has passed and has a pendingDomainMetadata prop,
+     * then we can assume that the motion's action is a domain action and we need to link this provisional DomainMetadata to the REAL Domain by creating
+     * a new DomainMetadata with the corresponding Domain item id.
+     */
     if (finalizedMotion.pendingDomainMetadata && yayWon) {
       await linkPendingDomainMetadataWithDomain(action, colonyAddress, finalizedMotion);
     }

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -39,7 +39,7 @@ export default async (event: ContractEvent): Promise<void> => {
       if (parsedDomainAction?.name === ColonyOperations.AddDomain) {
         const colonyClient = await networkClient.getColonyClient(colonyAddress);
         const domainCount = await colonyClient.getDomainCount();
-        const nativeDomainId = domainCount.add(1).toNumber();
+        const nativeDomainId = domainCount.toNumber(); // The new domain should be created by now, so we just get the total of existing domains and use that as an id
 
         await mutate('createDomainMetadata', {
           input: {

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -105,10 +105,48 @@ export interface StakerReward {
   isClaimed: boolean;
 }
 
+enum DomainColor {
+  LIGHT_PINK,
+  PINK,
+  BLACK,
+  EMERALD_GREEN,
+  BLUE,
+  YELLOW,
+  RED,
+  GREEN,
+  PERIWINKLE,
+  GOLD,
+  AQUA,
+  BLUE_GREY,
+  PURPLE,
+  ORANGE,
+  MAGENTA,
+  PURPLE_GREY,
+}
+
+interface DomainMetadataChangelog {
+  transactionHash: string;
+  oldName: string;
+  newName: string;
+  oldColor: DomainColor;
+  newColor: DomainColor;
+  oldDescription: string;
+  newDescription: string;
+}
+
+interface DomainMetadata {
+  id: string;
+  name: string;
+  description: string;
+  color: string;
+  changelog: [DomainMetadataChangelog];
+}
+
 export interface MotionQuery {
   id: string;
   motionData: MotionData;
   createdAt: string;
+  pendingDomainMetadata: DomainMetadata;
 }
 
 export interface MotionMessage {


### PR DESCRIPTION
CDapp counterpart: https://github.com/JoinColony/colonyCDapp/pull/471

`Domain` with their `DomainMetadata` created via motion:
![FireShot Capture 001 - Amplify GraphiQL Explorer - localhost](https://user-images.githubusercontent.com/18473896/234427041-5106f3e1-b193-4c6b-bbee-ce9b785ccc33.png)

Pending `DomainMetadata` of an edit to the domain previously created:
![FireShot Capture 002 - Amplify GraphiQL Explorer - localhost](https://user-images.githubusercontent.com/18473896/234427048-ca71ce43-c1c9-4459-9027-1ac821ec32b9.png)

The previous pending `DomainMetadata` now linked to the edited domain:
![FireShot Capture 003 - Amplify GraphiQL Explorer - localhost](https://user-images.githubusercontent.com/18473896/234427055-bec9518c-9eae-49a7-aae2-b935b723bfdb.png)
![FireShot Capture 004 - Amplify GraphiQL Explorer - localhost](https://user-images.githubusercontent.com/18473896/234427059-a7239eb9-9da9-4f54-bd13-59f46a9f6ea0.png)
