### PR TITLE
Fix rounding up to one for wrong stake side (motions)

### DIFF
--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -18,16 +18,24 @@ export const getRequiredStake = (
 export const getMotionStakes = (
   requiredStake: BigNumber,
   [totalNayStakesRaw, totalYayStakesRaw]: [BigNumber, BigNumber],
+  vote: BigNumber,
 ): MotionStakes => {
-  const totalYayStakesPercentage = getStakePercentage(
+  let totalYayStakesPercentage = getStakePercentage(
     totalYayStakesRaw,
     requiredStake,
   );
 
-  const totalNayStakesPercentage = getStakePercentage(
+  let totalNayStakesPercentage = getStakePercentage(
     totalNayStakesRaw,
     requiredStake,
   );
+
+  // May be zero due to rounding. Since a user cannot stake 0%, we round up to 1.
+  if (vote.eq(MotionVote.YAY) && totalYayStakesPercentage.isZero()) {
+    totalYayStakesPercentage = totalYayStakesPercentage.add(1);
+  } else if (vote.eq(MotionVote.NAY) && totalNayStakesPercentage.isZero()) {
+    totalNayStakesPercentage = totalYayStakesPercentage.add(1);
+  }
 
   const motionStakes: MotionStakes = {
     raw: {
@@ -55,16 +63,7 @@ export const getRemainingStakes = (
 export const getStakePercentage = (
   stake: BigNumber,
   requiredStake: BigNumber,
-): BigNumber => {
-  const percentage = stake.mul(100).div(requiredStake);
-
-  // May be zero due to rounding. Since a user cannot stake 0%, we round up to 1.
-  if (percentage.isZero()) {
-    return percentage.add(1);
-  }
-
-  return percentage;
-};
+): BigNumber => stake.mul(100).div(requiredStake);
 
 /**
  * Given staking data, format and return new UserStakes object

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -25,7 +25,7 @@ export default async (event: ContractEvent): Promise<void> => {
   const { skillRep, stakes } = await votingClient.getMotion(motionId);
 
   const requiredStake = getRequiredStake(skillRep, totalStakeFraction);
-  const motionStakes = getMotionStakes(requiredStake, stakes);
+  const motionStakes = getMotionStakes(requiredStake, stakes, vote);
   const remainingStakes = getRemainingStakes(requiredStake, stakes);
   const showInActionsList =
     Number(motionStakes.percentage.yay) + Number(motionStakes.percentage.nay) >=


### PR DESCRIPTION
This PR is a small fix to the staking calculation. I previously changed the logic so that if the stake percentage was 0, we'd show 1, since it'd only be 0 as a result of BigNumber rounding down (you cannot stake 0% of a motion). However, I failed to discriminate by vote side, meaning it currently affects both sides (which it shouldn't, since you can only stake one side at a time). 

This PR fixes that, such that staking one side doesn't cause the other side to be rounded up in the event its stake percentage is 0. 

You can test on the main cdapp motions branch. Check out and run block ingestor separately. Object a motion, and the yay side should remain at 0% and vice versa. 
