### PR TITLE
Separate MotionData from ColonyAction into its own model

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -227,7 +227,40 @@ export const queries = {
       getColonyActionByMotion(motionDataId: $motionDataId) {
         items {
           id
-          pendingDomainMetadata
+          pendingDomainMetadata {
+            name
+            color
+            description
+            changelog {
+              transactionHash
+              oldName
+              newName
+              oldColor
+              newColor
+              oldDescription
+              newDescription
+            }
+          }
+          pendingColonyMetadata {
+            id
+            displayName
+            avatar
+            thumbnail
+            changelog {
+              transactionHash
+              oldDisplayName
+              newDisplayName
+              hasAvatarChanged
+              hasWhitelistChanged
+              haveTokensChanged
+            }
+            isWhitelistActivated
+            whitelistedAddresses
+            modifiedTokenAddresses {
+              added
+              removed
+            }
+          }
         }
       }
     }
@@ -307,40 +340,6 @@ export const queries = {
           initiatorAddress
           vote
           amount
-        }
-        pendingDomainMetadata {
-          name
-          color
-          description
-          changelog {
-            transactionHash
-            oldName
-            newName
-            oldColor
-            newColor
-            oldDescription
-            newDescription
-          }
-          pendingColonyMetadata {
-            id
-            displayName
-            avatar
-            thumbnail
-            changelog {
-              transactionHash
-              oldDisplayName
-              newDisplayName
-              hasAvatarChanged
-              hasWhitelistChanged
-              haveTokensChanged
-            }
-            isWhitelistActivated
-            whitelistedAddresses
-            modifiedTokenAddresses {
-              added
-              removed
-            }
-          }
         }
       }
     }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -222,6 +222,15 @@ export const queries = {
       }
     }
   `,
+  getColonyActionByMotion: /* GraphQL */ `
+    query GetColonyActionByMotion($motionDataId: ID!) {
+      getColonyActionByMotion(motionDataId: $motionDataId) {
+        items {
+          id
+        }
+      }
+    }
+  `,
   getColonyMotion: /* GraphQL */ `
     query GetColonyMotion($id: ID!) {
       getColonyMotion(id: $id) {

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -292,7 +292,7 @@ export const queries = {
         repSubmitted
         skillRep
         hasObjection
-        motionNativeDomainId
+        nativeMotionDomainId
         motionStateHistory {
           hasVoted
           hasPassed

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -166,6 +166,13 @@ export const mutations = {
       }
     }
   `,
+  createMotionMessage: /* GraphQL */ `
+    mutation CreateMotionMessage($input: CreateMotionMessageInput!) {
+      createMotionMessage(input: $input) {
+        id
+      }
+    }
+  `,
 };
 
 /*
@@ -333,15 +340,6 @@ export const queries = {
           hasFailed
           hasFailedNotFinalizable
           inRevealPhase
-        }
-        messages {
-          items {
-            name
-            messageKey
-            initiatorAddress
-            vote
-            amount            
-          }
         }
       }
     }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -223,8 +223,8 @@ export const queries = {
     }
   `,
   getColonyActionByMotion: /* GraphQL */ `
-    query GetColonyActionByMotion($motionDataId: ID!) {
-      getColonyActionByMotion(motionDataId: $motionDataId) {
+    query GetColonyActionByMotion($motionId: ID!) {
+      getColonyActionByMotion(motionId: $motionId) {
         items {
           id
           pendingDomainMetadata {

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -153,14 +153,14 @@ export const mutations = {
     }
   `,
   createColonyMotion: /* GraphQL */ `
-    mutation CreateColonyMotion($input: ColonyMotionInput!) {
+    mutation CreateColonyMotion($input: CreateColonyMotionInput!) {
       createColonyMotion(input: $input) {
         id
       }
     }
   `,
   updateColonyMotion: /* GraphQL */ `
-    mutation UpdateColonyMotion($input: ColonyMotionInput!) {
+    mutation UpdateColonyMotion($input: UpdateColonyMotionInput!) {
       updateColonyMotion(input: $input) {
         id
       }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -222,9 +222,9 @@ export const queries = {
       }
     }
   `,
-  getColonyActionByMotion: /* GraphQL */ `
-    query GetColonyActionByMotion($motionId: ID!) {
-      getColonyActionByMotion(motionId: $motionId) {
+  getColonyActionByMotionId: /* GraphQL */ `
+    query GetColonyActionByMotionId($motionId: ID!) {
+      getColonyActionByMotionId(motionId: $motionId) {
         items {
           id
           pendingDomainMetadata {

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -152,6 +152,20 @@ export const mutations = {
       }
     }
   `,
+  createColonyMotion: /* GraphQL */ `
+    mutation CreateColonyMotion($input: CreateColonyMotionInput!) {
+      createColonyMotion(input: $input) {
+        id
+      }
+    }
+  `,
+  updateColonyMotion: /* GraphQL */ `
+    mutation UpdateColonyMotion($input: UpdateColonyMotionInput!) {
+      updateColonyMotion(input: $input) {
+        id
+      }
+    }
+  `,
 };
 
 /*
@@ -208,101 +222,94 @@ export const queries = {
       }
     }
   `,
-  getColonyMotions: /* GraphQL */ `
-    query GetActionsByColony($colonyAddress: ID!) {
-      getActionsByColony(
-        colonyId: $colonyAddress
-        filter: { isMotion: { eq: true } }
-      ) {
-        items {
-          id
-          motionData {
-            motionId
-            nativeMotionId
-            motionStakes {
-              raw {
-                nay
-                yay
-              }
-              percentage {
-                nay
-                yay
-              }
+  getColonyMotion: /* GraphQL */ `
+    query GetColonyMotion($id: ID!) {
+      getColonyMotion(id: $id) {
+        id
+        nativeMotionId
+        motionStakes {
+          raw {
+            nay
+            yay
+          }
+          percentage {
+            nay
+            yay
+          }
+        }
+        requiredStake
+        remainingStakes
+        usersStakes {
+          address
+          stakes {
+            raw {
+              yay
+              nay
             }
-            requiredStake
-            remainingStakes
-            usersStakes {
-              address
-              stakes {
-                raw {
-                  yay
-                  nay
-                }
-                percentage {
-                  yay
-                  nay
-                }
-              }
-            }
-            userMinStake
-            rootHash
-            motionDomainId
-            stakerRewards {
-              address
-              rewards {
-                yay
-                nay
-              }
-              isClaimed
-            }
-            isFinalized
-            createdBy
-            voterRecord {
-              address
-              voteCount
-              vote
-            }
-            revealedVotes {
-              raw {
-                yay
-                nay
-              }
-              percentage {
-                yay
-                nay
-              }
-            }
-            repSubmitted
-            skillRep
-            hasObjection
-            motionStateHistory {
-              hasVoted
-              hasPassed
-              hasFailed
-              hasFailedNotFinalizable
-              inRevealPhase
-            }
-            messages {
-              name
-              messageKey
-              initiatorAddress
-              vote
-              amount
+            percentage {
+              yay
+              nay
             }
           }
-          pendingDomainMetadata {
-            name
-            color
-            description
-            changelog {
-              transactionHash
-              oldName
-              newName
-              oldColor
-              newColor
-              oldDescription
-              newDescription
-            }
+        }
+        userMinStake
+        rootHash
+        motionDomainId
+        stakerRewards {
+          address
+          rewards {
+            yay
+            nay
+          }
+          isClaimed
+        }
+        isFinalized
+        createdBy
+        voterRecord {
+          address
+          voteCount
+          vote
+        }
+        revealedVotes {
+          raw {
+            yay
+            nay
+          }
+          percentage {
+            yay
+            nay
+          }
+        }
+        repSubmitted
+        skillRep
+        hasObjection
+        motionNativeDomainId
+        motionStateHistory {
+          hasVoted
+          hasPassed
+          hasFailed
+          hasFailedNotFinalizable
+          inRevealPhase
+        }
+        messages {
+          name
+          messageKey
+          initiatorAddress
+          vote
+          amount
+        }
+        pendingDomainMetadata {
+          name
+          color
+          description
+          changelog {
+            transactionHash
+            oldName
+            newName
+            oldColor
+            newColor
+            oldDescription
+            newDescription
           }
           pendingColonyMetadata {
             id

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -335,11 +335,13 @@ export const queries = {
           inRevealPhase
         }
         messages {
-          name
-          messageKey
-          initiatorAddress
-          vote
-          amount
+          items {
+            name
+            messageKey
+            initiatorAddress
+            vote
+            amount            
+          }
         }
       }
     }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -153,14 +153,14 @@ export const mutations = {
     }
   `,
   createColonyMotion: /* GraphQL */ `
-    mutation CreateColonyMotion($input: CreateColonyMotionInput!) {
+    mutation CreateColonyMotion($input: ColonyMotionInput!) {
       createColonyMotion(input: $input) {
         id
       }
     }
   `,
   updateColonyMotion: /* GraphQL */ `
-    mutation UpdateColonyMotion($input: UpdateColonyMotionInput!) {
+    mutation UpdateColonyMotion($input: ColonyMotionInput!) {
       updateColonyMotion(input: $input) {
         id
       }

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -254,7 +254,7 @@ export const queries = {
         }
         userMinStake
         rootHash
-        motionDomainId
+        nativeMotionDomainId
         stakerRewards {
           address
           rewards {

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -227,6 +227,7 @@ export const queries = {
       getColonyActionByMotion(motionDataId: $motionDataId) {
         items {
           id
+          pendingDomainMetadata
         }
       }
     }

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -21,7 +21,7 @@ export const updateMotionInDB = async (
   if (showInActionsList !== undefined) {
     const { items: colonyAction } =
       (await query<{ items: Array<{ id: string }> }>('getColonyActionByMotion', {
-        motionDataId: motionData.id,
+        motionId: motionData.id,
       })) ?? {};
 
     if (!colonyAction?.length) {

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -15,9 +15,28 @@ export const updateMotionInDB = async (
   await mutate('updateColonyMotion', {
     input: {
       ...motionData,
-      ...(showInActionsList === undefined ? {} : { showInActionsList }),
     },
   });
+
+  if (showInActionsList !== undefined) {
+    const colonyAction =
+      await query('getColonyActionByMotion', {
+        motionDataId: motionData.id,
+      });
+
+    if (!colonyAction) {
+      verbose(
+        'Could not find the action in the db. This is a bug and needs investigating.',
+      );
+    } else {
+      await mutate('updateColonyAction', {
+        input: {
+          id: colonyAction.id,
+          showInActionsList,
+        },
+      });
+    }
+  }
 };
 
 export const getMotionDatabaseId = (

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from 'ethers';
 import { mutate, query } from '~amplifyClient';
-import { ColonyMotion, MotionSide, MotionVote } from '~types';
+import { ColonyMotion, MotionMessage, MotionSide, MotionVote } from '~types';
 import { verbose } from '~utils';
 
 export * from './motionStaked/helpers';
@@ -10,6 +10,7 @@ export const getMotionSide = (vote: BigNumber): MotionSide =>
 
 export const updateMotionInDB = async (
   motionData: ColonyMotion,
+  newMotionMessages?: MotionMessage[],
   showInActionsList?: boolean,
 ): Promise<void> => {
   await mutate('updateColonyMotion', {
@@ -17,6 +18,16 @@ export const updateMotionInDB = async (
       ...motionData,
     },
   });
+
+  if (newMotionMessages?.length) {
+    for (const message of newMotionMessages) {
+      await mutate('createMotionMessage', {
+        input: {
+          ...message,
+        },
+      });
+    }
+  }
 
   if (showInActionsList !== undefined) {
     const { items: colonyActionItems } =

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -19,19 +19,19 @@ export const updateMotionInDB = async (
   });
 
   if (showInActionsList !== undefined) {
-    const colonyAction =
-      await query('getColonyActionByMotion', {
+    const { items: colonyAction } =
+      (await query<{ items: Array<{ id: string }> }>('getColonyActionByMotion', {
         motionDataId: motionData.id,
-      });
+      })) ?? {};
 
-    if (!colonyAction) {
+    if (!colonyAction?.length) {
       verbose(
         'Could not find the action in the db. This is a bug and needs investigating.',
       );
     } else {
       await mutate('updateColonyAction', {
         input: {
-          id: colonyAction.id,
+          id: colonyAction[0].id,
           showInActionsList,
         },
       });

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -20,7 +20,7 @@ export const updateMotionInDB = async (
 
   if (showInActionsList !== undefined) {
     const { items: colonyAction } =
-      (await query<{ items: Array<{ id: string }> }>('getColonyActionByMotion', {
+      (await query<{ items: Array<{ id: string }> }>('getColonyActionByMotionId', {
         motionId: motionData.id,
       })) ?? {};
 

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -19,19 +19,19 @@ export const updateMotionInDB = async (
   });
 
   if (showInActionsList !== undefined) {
-    const { items: colonyAction } =
+    const { items: colonyActionItems } =
       (await query<{ items: Array<{ id: string }> }>('getColonyActionByMotionId', {
         motionId: motionData.id,
       })) ?? {};
 
-    if (!colonyAction?.length) {
+    if (!colonyActionItems?.length) {
       verbose(
         'Could not find the action in the db. This is a bug and needs investigating.',
       );
     } else {
       await mutate('updateColonyAction', {
         input: {
-          id: colonyAction[0].id,
+          id: colonyActionItems[0].id,
           showInActionsList,
         },
       });

--- a/src/handlers/motions/helpers.ts
+++ b/src/handlers/motions/helpers.ts
@@ -31,7 +31,7 @@ export const getMotionFromDB = async (
 ): Promise<ColonyMotion | undefined> => {
   const motion =
     await query<ColonyMotion>('getColonyMotion', {
-      databaseMotionId,
+      id: databaseMotionId,
     });
 
   if (!motion) {

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -157,7 +157,7 @@ export const createMotionInDB = async (
       colonyId: colonyAddress,
       isMotion: true,
       showInActionsList: false,
-      motionDataId: motionData.id,
+      motionId: motionData.id,
       initiatorAddress: creatorAddress,
       blockNumber,
       ...input,

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -72,10 +72,15 @@ const getMotionData = async ({
   );
 
   const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
 
   return {
     createdBy: votingClient.address,
-    id: getMotionDatabaseId(chainId, votingClient.address, motionId),
+    id: motionDatabaseId,
     nativeMotionId: motionId.toString(),
     motionStakes: {
       raw: {
@@ -121,6 +126,7 @@ const getMotionData = async ({
         name: MotionEvents.MotionCreated,
         messageKey: getMessageKey(transactionHash, logIndex),
         initiatorAddress: creatorAddress,
+        motionId: motionDatabaseId,
       },
     ],
   };

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -44,7 +44,6 @@ interface Props {
   motionId: BigNumber;
   domainId: BigNumber;
   creatorAddress: string;
-  pendingDomainMetadataId: string | null;
 }
 
 const getMotionData = async ({
@@ -54,7 +53,6 @@ const getMotionData = async ({
   motionId,
   domainId,
   creatorAddress,
-  pendingDomainMetadataId,
 }: Props): Promise<ColonyMotion> => {
   const votingClient = await getVotingClient(colonyAddress);
   const { skillRep, rootHash, repSubmitted } = await votingClient.getMotion(
@@ -125,7 +123,6 @@ const getMotionData = async ({
         initiatorAddress: creatorAddress,
       },
     ],
-    pendingDomainMetadataId,
   };
 };
 
@@ -137,10 +134,7 @@ export const createMotionInDB = async (
     contractAddress: colonyAddress,
     args: { motionId, creator: creatorAddress, domainId },
   }: ContractEvent,
-  {
-    pendingDomainMetadataId,
-    ...inputRest
-  }: Record<string, any>,
+  input: Record<string, any>,
 ): Promise<void> => {
   const motionData = await getMotionData({
     colonyAddress,
@@ -149,7 +143,6 @@ export const createMotionInDB = async (
     motionId,
     domainId,
     creatorAddress,
-    pendingDomainMetadataId,
   });
 
   await mutate('createColonyMotion', {
@@ -167,7 +160,7 @@ export const createMotionInDB = async (
       motionDataId: motionData.id,
       initiatorAddress: creatorAddress,
       blockNumber,
-      ...inputRest,
+      ...input,
     },
   });
 };

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -94,7 +94,7 @@ const getMotionData = async ({
     usersStakes: [],
     userMinStake,
     rootHash,
-    motionNativeDomainId: domainId.toString(),
+    nativeMotionDomainId: domainId.toString(),
     stakerRewards: [],
     voterRecord: [],
     isFinalized: false,

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -99,7 +99,7 @@ export const linkPendingDomainMetadataWithDomain = async (
   if (isMotionAddingADomain || isMotionEditingADomain) {
     const { items: colonyAction } =
       (await query<{ items: Array<{ id: string, pendingDomainMetadata: DomainMetadata }> }>('getColonyActionByMotion', {
-        motionDataId: finalizedMotion.id,
+        motionId: finalizedMotion.id,
       })) ?? {};
     const pendingDomainMetadata = colonyAction?.[0]?.pendingDomainMetadata;
 

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -98,7 +98,7 @@ export const linkPendingDomainMetadataWithDomain = async (
 
   if (isMotionAddingADomain || isMotionEditingADomain) {
     const { items: colonyAction } =
-      (await query<{ items: Array<{ id: string, pendingDomainMetadata: DomainMetadata }> }>('getColonyActionByMotion', {
+      (await query<{ items: Array<{ id: string, pendingDomainMetadata: DomainMetadata }> }>('getColonyActionByMotionId', {
         motionId: finalizedMotion.id,
       })) ?? {};
     const pendingDomainMetadata = colonyAction?.[0]?.pendingDomainMetadata;

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -8,6 +8,7 @@ import {
   MotionVote,
   StakerReward,
   ColonyMotion,
+  MotionQuery,
 } from '~types';
 import {
   getColonyFromDB,
@@ -67,8 +68,8 @@ export const getStakerReward = async (
   };
 };
 
-const getParsedActionFromDomainMotion = async (
-  domainAction: string,
+const getParsedActionFromMotion = async (
+  action: string,
   colonyAddress: string,
 ): Promise<TransactionDescription | undefined> => {
   const colonyClient = await networkClient.getColonyClient(colonyAddress);
@@ -76,106 +77,92 @@ const getParsedActionFromDomainMotion = async (
   // We are only parsing this action in order to know if it's a add/edit domain motion. Therefore, we shouldn't need to try with any other client.
   try {
     return colonyClient.interface.parseTransaction({
-      data: domainAction,
+      data: action,
     });
   } catch {
-    verbose(`Unable to parse ${domainAction} using colony client`);
+    verbose(`Unable to parse ${action} using colony client`);
     return undefined;
   }
 };
 
-export const linkPendingDomainMetadataWithDomain = async (
-  action: string,
+const linkPendingDomainMetadataWithDomain = async (
+  pendingDomainMetadata: DomainMetadata,
   colonyAddress: string,
-  finalizedMotion: ColonyMotion,
+  isEditingADomain: boolean,
+  parsedAction: TransactionDescription,
 ): Promise<void> => {
-  const parsedDomainAction = await getParsedActionFromDomainMotion(
-    action,
-    colonyAddress,
-  );
-  const isMotionAddingADomain = parsedDomainAction?.name === ColonyOperations.AddDomain;
-  const isMotionEditingADomain = parsedDomainAction?.name === ColonyOperations.EditDomain;
+  if (!isEditingADomain) {
+    const colonyClient = await networkClient.getColonyClient(colonyAddress);
+    const domainCount = await colonyClient.getDomainCount();
+    // The new domain should be created by now, so we just get the total of existing domains
+    // and use that as an id to link the pending metadata.
+    const nativeDomainId = domainCount.toNumber();
 
-  if (isMotionAddingADomain || isMotionEditingADomain) {
-    const { items: colonyAction } =
-      (await query<{ items: Array<{ id: string, pendingDomainMetadata: DomainMetadata }> }>('getColonyActionByMotionId', {
-        motionId: finalizedMotion.id,
-      })) ?? {};
-    const pendingDomainMetadata = colonyAction?.[0]?.pendingDomainMetadata;
+    await mutate('createDomainMetadata', {
+      input: {
+        ...pendingDomainMetadata,
+        id: getDomainDatabaseId(colonyAddress, nativeDomainId),
+      },
+    });
+  } else if (isEditingADomain) {
+    const nativeDomainId = parsedAction.args[2].toNumber(); // domainId arg from editDomain action
+    const databaseDomainId = getDomainDatabaseId(colonyAddress, nativeDomainId);
 
-    if (isMotionAddingADomain) {
-      const colonyClient = await networkClient.getColonyClient(colonyAddress);
-      const domainCount = await colonyClient.getDomainCount();
-      // The new domain should be created by now, so we just get the total of existing domains
-      // and use that as an id to link the pending metadata.
-      const nativeDomainId = domainCount.toNumber();
+    const currentDomainMetadata = await query<DomainMetadata>(
+      'getDomainMetadata',
+      {
+        id: databaseDomainId,
+      },
+    );
 
-      await mutate('createDomainMetadata', {
-        input: {
-          ...pendingDomainMetadata,
-          id: getDomainDatabaseId(colonyAddress, nativeDomainId),
-        },
-      });
-    } else if (parsedDomainAction?.name === ColonyOperations.EditDomain) {
-      const nativeDomainId = parsedDomainAction.args[2].toNumber(); // domainId arg from editDomain action
-      const databaseDomainId = getDomainDatabaseId(colonyAddress, nativeDomainId);
-
-      const currentDomainMetadata = await query<DomainMetadata>(
-        'getDomainMetadata',
-        {
-          id: databaseDomainId,
-        },
-      );
-
-      const updatedMetadata = {
-        ...currentDomainMetadata,
-      };
-
-      const pendingChangelog = pendingDomainMetadata?.changelog ?? [];
-
-      if (!pendingChangelog.length) {
-        console.error(
-          `Pending changelog for domain with database id: ${databaseDomainId} could not be found.
-          This is a bug and should be investigated.`,
-        );
-      }
-
-      const {
-        newColor,
-        newDescription,
-        newName,
-        oldColor,
-        oldDescription,
-        oldName,
-      } = pendingChangelog[pendingChangelog.length - 1] ?? {};
-
-      const hasColorChanged = newColor !== oldColor;
-      const hasDescriptionChanged = newDescription !== oldDescription;
-      const hasNameChanged = newName !== oldName;
-
-      if (hasColorChanged) {
-        updatedMetadata.color = newColor;
-      }
-
-      if (hasDescriptionChanged) {
-        updatedMetadata.description = newDescription;
-      }
-
-      if (hasNameChanged) {
-        updatedMetadata.name = newName;
-      }
-
-      await mutate('updateDomainMetadata', {
-        input: {
-          ...updatedMetadata,
-          id: databaseDomainId,
-        },
-      });
+    const updatedMetadata = {
+      ...currentDomainMetadata,
     };
+
+    const pendingChangelog = pendingDomainMetadata?.changelog ?? [];
+
+    if (!pendingChangelog.length) {
+      console.error(
+        `Pending changelog for domain with database id: ${databaseDomainId} could not be found.
+        This is a bug and should be investigated.`,
+      );
+    }
+
+    const {
+      newColor,
+      newDescription,
+      newName,
+      oldColor,
+      oldDescription,
+      oldName,
+    } = pendingChangelog[pendingChangelog.length - 1] ?? {};
+
+    const hasColorChanged = newColor !== oldColor;
+    const hasDescriptionChanged = newDescription !== oldDescription;
+    const hasNameChanged = newName !== oldName;
+
+    if (hasColorChanged) {
+      updatedMetadata.color = newColor;
+    }
+
+    if (hasDescriptionChanged) {
+      updatedMetadata.description = newDescription;
+    }
+
+    if (hasNameChanged) {
+      updatedMetadata.name = newName;
+    }
+
+    await mutate('updateDomainMetadata', {
+      input: {
+        ...updatedMetadata,
+        id: databaseDomainId,
+      },
+    });
   };
 };
 
-export const linkPendingColonyMetadataWithColony = async (
+const linkPendingColonyMetadataWithColony = async (
   pendingColonyMetadata: ColonyMetadata,
   colonyAddress: string,
 ): Promise<void> => {
@@ -254,4 +241,41 @@ export const linkPendingColonyMetadataWithColony = async (
       ],
     },
   });
+};
+
+export const linkPendingMetadata = async (action: string, colonyAddress: string, finalizedMotion: ColonyMotion): Promise<void> => {
+  const parsedAction = await getParsedActionFromMotion(
+    action,
+    colonyAddress,
+  );
+
+  const isMotionAddingADomain = parsedAction?.name === ColonyOperations.AddDomain;
+  const isMotionEditingADomain = parsedAction?.name === ColonyOperations.EditDomain;
+  const isMotionEditingAColony = parsedAction?.name === ColonyOperations.EditColony;
+
+  if (isMotionAddingADomain || isMotionEditingADomain || isMotionEditingAColony) {
+    const { items: colonyAction } =
+      (await query<{ items: MotionQuery[] }>('getColonyActionByMotionId', {
+        motionId: finalizedMotion.id,
+      })) ?? {};
+    /*
+     * pendingDomainMetadata is a motion data prop that we use to store the metadata of a Domain that COULD be created/edited
+     * if the YAY side of the motion won and the motion was finalized. In this step, if the motion has passed and has a pendingDomainMetadata prop,
+     * then we can assume that the motion's action is a domain action and we need to link this provisional DomainMetadata to the REAL Domain by creating
+     * a new DomainMetadata with the corresponding Domain item id.
+     */
+    if ((isMotionAddingADomain || isMotionEditingADomain) && colonyAction?.[0]?.pendingDomainMetadata) {
+      await linkPendingDomainMetadataWithDomain(
+        colonyAction[0].pendingDomainMetadata,
+        colonyAddress,
+        isMotionEditingADomain,
+        parsedAction,
+      );
+    } else if (isMotionEditingAColony && colonyAction?.[0]?.pendingColonyMetadata) {
+      await linkPendingColonyMetadataWithColony(
+        colonyAction[0].pendingColonyMetadata,
+        colonyAddress,
+      );
+    }
+  }
 };

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -54,11 +54,11 @@ export default async (event: ContractEvent): Promise<void> => {
      * then we can assume that the motion's action is a domain action and we need to link this provisional DomainMetadata to the REAL Domain by creating
      * a new DomainMetadata with the corresponding Domain item id.
      */
-    if (finalizedMotion.pendingDomainMetadata && yayWon) {
+    if (yayWon) {
       await linkPendingDomainMetadataWithDomain(
         action,
         colonyAddress,
-        finalizedMotion.pendingDomainMetadata,
+        finalizedMotion,
       );
     }
 

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -12,8 +12,7 @@ import {
 
 import {
   getStakerReward,
-  linkPendingColonyMetadataWithColony,
-  linkPendingDomainMetadataWithDomain,
+  linkPendingMetadata,
 } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
@@ -48,25 +47,8 @@ export default async (event: ContractEvent): Promise<void> => {
       BigNumber.from(yayVotes).gt(nayVotes) ||
       Number(yayPercentage) > Number(nayPercentage);
 
-    /*
-     * pendingDomainMetadata is a motion data prop that we use to store the metadata of a Domain that COULD be created/edited
-     * if the YAY side of the motion won and the motion was finalized. In this step, if the motion has passed and has a pendingDomainMetadata prop,
-     * then we can assume that the motion's action is a domain action and we need to link this provisional DomainMetadata to the REAL Domain by creating
-     * a new DomainMetadata with the corresponding Domain item id.
-     */
     if (yayWon) {
-      await linkPendingDomainMetadataWithDomain(
-        action,
-        colonyAddress,
-        finalizedMotion,
-      );
-    }
-
-    if (finalizedMotion.pendingColonyMetadata && yayWon) {
-      await linkPendingColonyMetadataWithColony(
-        finalizedMotion.pendingColonyMetadata,
-        colonyAddress,
-      );
+      await linkPendingMetadata(action, colonyAddress, finalizedMotion);
     }
 
     const updatedStakerRewards = await Promise.all(

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -31,23 +31,17 @@ export default async (event: ContractEvent): Promise<void> => {
     votingClient.address,
     motionId,
   );
-  const finalizedMotion = await getMotionFromDB(
-    colonyAddress,
-    motionDatabaseId,
-  );
+  const finalizedMotion = await getMotionFromDB(motionDatabaseId);
   if (finalizedMotion) {
     const {
-      motionData: {
-        usersStakes,
-        revealedVotes: {
-          raw: { yay: yayVotes, nay: nayVotes },
-        },
-        motionStakes: {
-          percentage: { yay: yayPercentage, nay: nayPercentage },
-        },
-        messages,
+      usersStakes,
+      revealedVotes: {
+        raw: { yay: yayVotes, nay: nayVotes },
       },
-      motionData,
+      motionStakes: {
+        percentage: { yay: yayPercentage, nay: nayPercentage },
+      },
+      messages,
     } = finalizedMotion;
 
     const yayWon =
@@ -92,12 +86,12 @@ export default async (event: ContractEvent): Promise<void> => {
     ];
 
     const updatedMotionData = {
-      ...motionData,
+      ...finalizedMotion,
       stakerRewards: updatedStakerRewards,
       isFinalized: true,
       messages: updatedMessages,
     };
 
-    await updateMotionInDB(finalizedMotion.id, updatedMotionData);
+    await updateMotionInDB(updatedMotionData);
   }
 };

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -64,6 +64,7 @@ export default async (event: ContractEvent): Promise<void> => {
         initiatorAddress: constants.AddressZero,
         name: MotionEvents.MotionFinalized,
         messageKey: getMessageKey(transactionHash, logIndex),
+        motionId: motionDatabaseId,
       },
     ];
 

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -40,7 +40,6 @@ export default async (event: ContractEvent): Promise<void> => {
       motionStakes: {
         percentage: { yay: yayPercentage, nay: nayPercentage },
       },
-      messages,
     } = finalizedMotion;
 
     const yayWon =
@@ -58,8 +57,7 @@ export default async (event: ContractEvent): Promise<void> => {
       ),
     );
 
-    const updatedMessages = [
-      ...messages,
+    const newMotionMessages = [
       {
         initiatorAddress: constants.AddressZero,
         name: MotionEvents.MotionFinalized,
@@ -72,9 +70,8 @@ export default async (event: ContractEvent): Promise<void> => {
       ...finalizedMotion,
       stakerRewards: updatedStakerRewards,
       isFinalized: true,
-      messages: updatedMessages,
     };
 
-    await updateMotionInDB(updatedMotionData);
+    await updateMotionInDB(updatedMotionData, newMotionMessages);
   }
 };

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -1,4 +1,4 @@
-import { ContractEvent, MotionData, MotionEvents } from '~types';
+import { ContractEvent, ColonyMotion, MotionEvents } from '~types';
 import { getVotingClient } from '~utils';
 import {
   getMotionDatabaseId,
@@ -22,11 +22,12 @@ export default async (event: ContractEvent): Promise<void> => {
     votingClient.address,
     motionId,
   );
-  const claimedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
+  const claimedMotion = await getMotionFromDB(motionDatabaseId);
 
   if (claimedMotion) {
     const {
-      motionData: { stakerRewards, messages },
+      stakerRewards,
+      messages,
     } = claimedMotion;
 
     const updatedStakerRewards = stakerRewards.map((stakerReward) => {
@@ -48,8 +49,8 @@ export default async (event: ContractEvent): Promise<void> => {
       };
     });
 
-    const updatedMotionData: MotionData = {
-      ...claimedMotion.motionData,
+    const updatedMotionData: ColonyMotion = {
+      ...claimedMotion,
       stakerRewards: updatedStakerRewards,
       messages: [
         ...messages,
@@ -61,6 +62,6 @@ export default async (event: ContractEvent): Promise<void> => {
       ],
     };
 
-    await updateMotionInDB(claimedMotion.id, updatedMotionData);
+    await updateMotionInDB(updatedMotionData);
   }
 };

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -27,7 +27,6 @@ export default async (event: ContractEvent): Promise<void> => {
   if (claimedMotion) {
     const {
       stakerRewards,
-      messages,
     } = claimedMotion;
 
     const updatedStakerRewards = stakerRewards.map((stakerReward) => {
@@ -49,20 +48,20 @@ export default async (event: ContractEvent): Promise<void> => {
       };
     });
 
+    const newMotionMessages = [
+      {
+        name: MotionEvents.MotionRewardClaimed,
+        messageKey: getMessageKey(transactionHash, logIndex),
+        initiatorAddress: staker,
+        motionId: motionDatabaseId,
+      },
+    ];
+
     const updatedMotionData: ColonyMotion = {
       ...claimedMotion,
       stakerRewards: updatedStakerRewards,
-      messages: [
-        ...messages,
-        {
-          name: MotionEvents.MotionRewardClaimed,
-          messageKey: getMessageKey(transactionHash, logIndex),
-          initiatorAddress: staker,
-          motionId: motionDatabaseId,
-        },
-      ],
     };
 
-    await updateMotionInDB(updatedMotionData);
+    await updateMotionInDB(updatedMotionData, newMotionMessages);
   }
 };

--- a/src/handlers/motions/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed.ts
@@ -58,6 +58,7 @@ export default async (event: ContractEvent): Promise<void> => {
           name: MotionEvents.MotionRewardClaimed,
           messageKey: getMessageKey(transactionHash, logIndex),
           initiatorAddress: staker,
+          motionId: motionDatabaseId,
         },
       ],
     };

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -191,7 +191,6 @@ export const getUserMinStake = (
 
 interface Props {
   motionData: ColonyMotion;
-  messages: MotionMessage[];
   requiredStake: BigNumber;
   motionStakes: MotionStakes;
   messageKey: string;
@@ -202,7 +201,6 @@ interface Props {
 
 export const getUpdatedMessages = ({
   motionData,
-  messages,
   requiredStake,
   motionStakes,
   messageKey,
@@ -210,7 +208,7 @@ export const getUpdatedMessages = ({
   staker,
   amount,
 }: Props): MotionMessage[] => {
-  const updatedMessages = [...messages];
+  const updatedMessages = [];
   const isFirstObjection = vote.eq(MotionVote.NAY) && !motionData.hasObjection;
   const isFullyYayStaked =
     vote.eq(MotionVote.YAY) && requiredStake.eq(motionStakes.raw.yay);

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -226,6 +226,7 @@ export const getUpdatedMessages = ({
       name: MotionEvents.ObjectionRaised,
       messageKey: `${messageKey}_${MotionEvents.ObjectionRaised}}`,
       initiatorAddress: staker,
+      motionId: motionData.id,
     });
   }
 
@@ -235,6 +236,7 @@ export const getUpdatedMessages = ({
     initiatorAddress: staker,
     vote: vote.toString(),
     amount: amount.toString(),
+    motionId: motionData.id,
   });
 
   if (isFullyYayStaked) {
@@ -245,6 +247,7 @@ export const getUpdatedMessages = ({
       name: messageName,
       messageKey: `${messageKey}_${messageName}`,
       initiatorAddress: staker,
+      motionId: motionData.id,
     });
   }
 
@@ -257,6 +260,7 @@ export const getUpdatedMessages = ({
       name: MotionEvents.ObjectionFullyStaked,
       messageKey: `${messageKey}_${MotionEvents.ObjectionFullyStaked}`,
       initiatorAddress: staker,
+      motionId: motionData.id,
     });
   }
 
@@ -265,6 +269,7 @@ export const getUpdatedMessages = ({
       name: MotionEvents.MotionVotingPhase,
       messageKey: `${messageKey}_${MotionEvents.MotionVotingPhase}`,
       initiatorAddress: constants.AddressZero,
+      motionId: motionData.id,
     });
   }
 

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -3,7 +3,7 @@ import {
   MotionStakes,
   UserStakes,
   MotionMessage,
-  MotionData,
+  ColonyMotion,
   MotionVote,
   MotionEvents,
 } from '~types';
@@ -190,7 +190,7 @@ export const getUserMinStake = (
 };
 
 interface Props {
-  motionData: MotionData;
+  motionData: ColonyMotion;
   messages: MotionMessage[];
   requiredStake: BigNumber;
   motionStakes: MotionStakes;

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -42,7 +42,6 @@ export default async (event: ContractEvent): Promise<void> => {
   if (stakedMotion) {
     const {
       usersStakes,
-      messages,
     } = stakedMotion;
 
     const updatedUserStakes = getUpdatedUsersStakes(
@@ -52,9 +51,8 @@ export default async (event: ContractEvent): Promise<void> => {
       amount,
       requiredStake,
     );
-    const updatedMessages = getUpdatedMessages({
+    const newMotionMessages = getUpdatedMessages({
       motionData: stakedMotion,
-      messages,
       requiredStake,
       motionStakes,
       messageKey: getMessageKey(transactionHash, logIndex),
@@ -69,8 +67,8 @@ export default async (event: ContractEvent): Promise<void> => {
         usersStakes: updatedUserStakes,
         motionStakes,
         remainingStakes,
-        messages: updatedMessages,
       },
+      newMotionMessages,
       showInActionsList,
     );
 

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -37,13 +37,12 @@ export default async (event: ContractEvent): Promise<void> => {
     votingClient.address,
     motionId,
   );
-  const stakedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
+  const stakedMotion = await getMotionFromDB(motionDatabaseId);
 
   if (stakedMotion) {
     const {
-      id,
-      motionData: { usersStakes, messages },
-      motionData,
+      usersStakes,
+      messages,
     } = stakedMotion;
 
     const updatedUserStakes = getUpdatedUsersStakes(
@@ -54,7 +53,7 @@ export default async (event: ContractEvent): Promise<void> => {
       requiredStake,
     );
     const updatedMessages = getUpdatedMessages({
-      motionData,
+      motionData: stakedMotion,
       messages,
       requiredStake,
       motionStakes,
@@ -65,9 +64,8 @@ export default async (event: ContractEvent): Promise<void> => {
     });
 
     await updateMotionInDB(
-      id,
       {
-        ...motionData,
+        ...stakedMotion,
         usersStakes: updatedUserStakes,
         motionStakes,
         remainingStakes,

--- a/src/handlers/motions/motionVoteRevealed/index.ts
+++ b/src/handlers/motions/motionVoteRevealed/index.ts
@@ -22,13 +22,11 @@ export default async (event: ContractEvent): Promise<void> => {
     votingClient.address,
     motionId,
   );
-  const revealedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
+  const revealedMotion = await getMotionFromDB(motionDatabaseId);
 
   if (revealedMotion) {
     const {
-      id,
-      motionData: { voterRecord },
-      motionData,
+      voterRecord,
     } = revealedMotion;
     const updatedVoterRecord = voterRecord.map((record) => {
       const { address } = record;
@@ -47,8 +45,8 @@ export default async (event: ContractEvent): Promise<void> => {
     const totalVotes = nayVotes.add(yayVotes);
     const yayVotePercentage = yayVotes.mul(100).div(totalVotes);
     const nayVotePercentage = nayVotes.mul(100).div(totalVotes);
-    await updateMotionInDB(id, {
-      ...motionData,
+    await updateMotionInDB({
+      ...revealedMotion,
       voterRecord: updatedVoterRecord,
       revealedVotes: {
         raw: {

--- a/src/handlers/motions/motionVoteSubmitted/index.ts
+++ b/src/handlers/motions/motionVoteSubmitted/index.ts
@@ -34,7 +34,7 @@ export default async (event: ContractEvent): Promise<void> => {
       voterRecord: updatedVoterRecord,
       repSubmitted: repSubmitted.toString(),
       motionStateHistory: {
-        ...motionData.motionStateHistory,
+        ...votedMotion.motionStateHistory,
         hasVoted: true,
       },
     });

--- a/src/handlers/motions/motionVoteSubmitted/index.ts
+++ b/src/handlers/motions/motionVoteSubmitted/index.ts
@@ -21,18 +21,16 @@ export default async (event: ContractEvent): Promise<void> => {
     votingClient.address,
     motionId,
   );
-  const votedMotion = await getMotionFromDB(colonyAddress, motionDatabaseId);
+  const votedMotion = await getMotionFromDB(motionDatabaseId);
 
   if (votedMotion) {
     const {
-      id,
-      motionData: { voterRecord },
-      motionData,
+      voterRecord,
     } = votedMotion;
 
     const updatedVoterRecord = getUpdatedVoterRecord(voterRecord, voter);
-    await updateMotionInDB(id, {
-      ...motionData,
+    await updateMotionInDB({
+      ...votedMotion,
       voterRecord: updatedVoterRecord,
       repSubmitted: repSubmitted.toString(),
       motionStateHistory: {

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,0 +1,23 @@
+export interface ColonyActionInput {
+  type: string;
+  [key: string]: any;
+}
+
+export interface ColonyAction {
+  id: string;
+  colonyId: string;
+  type: string;
+  blockNumber: number;
+  showInActionsList: boolean;
+  initiatorAddress: string;
+  isMotion?: boolean;
+  motionId?: string;
+  recipientAddress?: string;
+  amount?: string;
+  tokenAddress?: string;
+  fromDomainId?: string;
+  toDomainId?: string;
+  fundamentalChainId?: number;
+  newColonyVersion?: number;
+  pendingDomainMetadataId?: string;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -116,6 +116,8 @@ export type Filter = Parameters<typeof getLogs>[1];
 // Export here to avoid circular dependency with ColonyActionType
 export * from './motions';
 
+export * from './actions';
+
 export type NetworkClients =
   | ColonyNetworkClient
   | TokenClient

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -193,6 +193,7 @@ export interface MotionQuery {
 export interface MotionMessage {
   name: string;
   messageKey: string;
+  motionId: string;
   initiatorAddress?: string;
   vote?: string;
   amount?: string;

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -96,7 +96,7 @@ export interface ColonyMotion {
   userMinStake: string;
   requiredStake: string;
   rootHash: string; // For calculating user's max stake in client
-  motionNativeDomainId: string;
+  nativeMotionDomainId: string;
   stakerRewards: StakerReward[];
   isFinalized: boolean;
   createdBy: string;

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -107,8 +107,6 @@ export interface ColonyMotion {
   hasObjection: boolean;
   motionStateHistory: MotionStateHistory;
   messages: MotionMessage[];
-  pendingDomainMetadataId: string | null;
-  pendingDomainMetadata?: DomainMetadata;
 }
 
 export interface UserStakes {

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -87,8 +87,8 @@ export interface MotionStateHistory {
   inRevealPhase: boolean;
 }
 
-export interface MotionData {
-  motionId: string;
+export interface ColonyMotion {
+  id: string;
   nativeMotionId: string;
   usersStakes: UserStakes[];
   motionStakes: MotionStakes;
@@ -96,7 +96,7 @@ export interface MotionData {
   userMinStake: string;
   requiredStake: string;
   rootHash: string; // For calculating user's max stake in client
-  motionDomainId: string;
+  motionNativeDomainId: string;
   stakerRewards: StakerReward[];
   isFinalized: boolean;
   createdBy: string;
@@ -107,6 +107,8 @@ export interface MotionData {
   hasObjection: boolean;
   motionStateHistory: MotionStateHistory;
   messages: MotionMessage[];
+  pendingDomainMetadataId: string | null;
+  pendingDomainMetadata?: DomainMetadata;
 }
 
 export interface UserStakes {
@@ -184,7 +186,7 @@ export interface ColonyMetadata {
 
 export interface MotionQuery {
   id: string;
-  motionData: MotionData;
+  motionData: ColonyMotion;
   createdAt: string;
   pendingDomainMetadata: DomainMetadata;
   pendingColonyMetadata: ColonyMetadata;

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -106,7 +106,6 @@ export interface ColonyMotion {
   skillRep: string;
   hasObjection: boolean;
   motionStateHistory: MotionStateHistory;
-  messages: MotionMessage[];
 }
 
 export interface UserStakes {


### PR DESCRIPTION
Moved `motionData` inside `ColonyAction` to their own model (`ColonyMotion`). Let me know if there's any part inside the ingestor that I forgot to update.

Also made some changes to how we create motion messages to actually link them to the motions.

`colonyCDapp`'s counterpart PR: https://github.com/JoinColony/colonyCDapp/pull/527

Resolves colonyCDapp#356