### PR TITLE
Track extensions, colonies and actions from the latest processed block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,4 @@ dist
 # TernJS port file
 .tern-port
 
-run
+stats

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "ethers": "^5.7.2",
         "express": "^4.18.2",
         "fs-extra": "^10.1.0",
-        "graphql": "^16.6.0"
+        "graphql": "^16.6.0",
+        "node-persist": "^3.1.3"
       },
       "devDependencies": {
         "@graphql-codegen/cli": "^3.3.1",
@@ -26,6 +27,7 @@
         "@types/express": "^4.17.14",
         "@types/fs-extra": "^9.0.13",
         "@types/node": "^18.11.9",
+        "@types/node-persist": "^3.1.3",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.8.0",
@@ -8048,9 +8050,9 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.1.0.tgz",
-      "integrity": "sha512-t4x3IOjyT+fxz6EIoQ4073N7cumPwb0GYwoaYUvJZlJtMzOm5tk8oFvE6puYaQjlsmHMU/VJvvWVZlJ1GIPzoQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.3.6.tgz",
+      "integrity": "sha512-vfmby0kKiwKjmBt1O/YD5iv8SGVebHg5DucTYYleW6gc7I5VtMonlgFCwGEwWtgPZWEgvJskDUcya/bZYrTBTg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
       },
@@ -8855,31 +8857,6 @@
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/@graphql-codegen/cli/node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@graphql-codegen/cli/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -8893,12 +8870,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
     },
     "node_modules/@graphql-codegen/cli/node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -8914,42 +8885,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/listr2": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
-      "dev": true,
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.16",
-        "log-update": "^4.0.0",
-        "p-map": "^4.0.0",
-        "rfdc": "^1.3.0",
-        "rxjs": "^7.5.5",
-        "through": "^2.3.8",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
-      },
-      "peerDependenciesMeta": {
-        "enquirer": {
-          "optional": true
-        }
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/parse-json": {
@@ -8968,20 +8903,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/wrap-ansi": {
@@ -9008,15 +8929,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@graphql-codegen/cli/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/@graphql-codegen/cli/node_modules/yargs": {
@@ -9280,9 +9192,9 @@
       }
     },
     "node_modules/@graphql-tools/executor-http": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.9.tgz",
-      "integrity": "sha512-tNzMt5qc1ptlHKfpSv9wVBVKCZ7gks6Yb/JcYJluxZIT4qRV+TtOFjpptfBU63usgrGVOVcGjzWc/mt7KhmmpQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.10.tgz",
+      "integrity": "sha512-hnAfbKv0/lb9s31LhWzawQ5hghBfHS+gYWtqxME6Rl0Aufq9GltiiLBcl7OVVOnkLF0KhwgbYP1mB5VKmgTGpg==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^9.2.1",
@@ -9336,9 +9248,9 @@
       }
     },
     "node_modules/@graphql-tools/git-loader": {
-      "version": "7.2.22",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.2.22.tgz",
-      "integrity": "sha512-9rpHggHiOeqA7/ZlKD3c5yXk5bPGw0zkIgKMerjCmFAQAZ6CEVfsa7nAzEWQxn6rpdaBft4/0A56rPMrsUwGBA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.3.0.tgz",
+      "integrity": "sha512-gcGAK+u16eHkwsMYqqghZbmDquh8QaO24Scsxq+cVR+vx1ekRlsEiXvu+yXVDbZdcJ6PBIbeLcQbEu+xhDLmvQ==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/graphql-tag-pluck": "7.5.2",
@@ -9457,9 +9369,9 @@
       }
     },
     "node_modules/@graphql-tools/merge": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.1.tgz",
-      "integrity": "sha512-hssnPpZ818mxgl5+GfyOOSnnflAxiaTn1A1AojZcIbh4J52sS1Q0gSuBR5VrnUDjuxiqoCotpXdAQl+K+U6KLQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^9.2.1",
@@ -9482,9 +9394,9 @@
       }
     },
     "node_modules/@graphql-tools/prisma-loader": {
-      "version": "7.2.71",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.71.tgz",
-      "integrity": "sha512-FuIvhRrkduqPdj3QX0/anCxGViEETfoZ/1NvotfM6iVO1XxR75VXvP/iyKGbK6XvYRXwSstgj2DetlQnqdgXhA==",
+      "version": "7.2.72",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.72.tgz",
+      "integrity": "sha512-0a7uV7Fky6yDqd0tI9+XMuvgIo6GAqiVzzzFV4OSLry4AwiQlI3igYseBV7ZVOGhedOTqj/URxjpiv07hRcwag==",
       "dev": true,
       "dependencies": {
         "@graphql-tools/url-loader": "^7.17.18",
@@ -9496,8 +9408,8 @@
         "debug": "^4.3.1",
         "dotenv": "^16.0.0",
         "graphql-request": "^6.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
+        "http-proxy-agent": "^6.0.0",
+        "https-proxy-agent": "^6.0.0",
         "jose": "^4.11.4",
         "js-yaml": "^4.0.0",
         "json-stable-stringify": "^1.0.1",
@@ -10365,15 +10277,6 @@
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
       "peer": true
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -10543,6 +10446,15 @@
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+    },
+    "node_modules/@types/node-persist": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/node-persist/-/node-persist-3.1.3.tgz",
+      "integrity": "sha512-6MdN3tQcBdlnswJ/JGJYEwWh72Ru3RHH3I16PCQ/GB7ecM3YFfcUB4Yysim6HHnKbCse5vgk5r51JKR7w5zE0Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -11058,15 +10970,15 @@
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.0.1.tgz",
+      "integrity": "sha512-V9to8gr2GK7eA+xskWGAFUX/TLSQKuH2TI06c/jGLL6yLp3oEjtnqM7a5tPV9fC1rabLeAgThZeBwsYX+WWHpw==",
       "dev": true,
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/agent-base/node_modules/debug": {
@@ -14840,17 +14752,16 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-6.0.1.tgz",
+      "integrity": "sha512-rD8wrfJHbnVll9lkIpQH3vDbKON1Ssciggwydom/r89HLBXEqdMhL6wx7QF5WePDPSr0OdoztdXoojbrXadG5Q==",
       "dev": true,
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.0.1",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/http-proxy-agent/node_modules/debug": {
@@ -14877,16 +14788,16 @@
       "dev": true
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-6.1.0.tgz",
+      "integrity": "sha512-rvGRAlc3y+iS7AC9Os2joN91mX8wHpJ4TEklmHHxr7Gz2Juqa7fJmJ8wWxXNpTaRt56MQTwojxV5d82UW/+jwg==",
       "dev": true,
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.1",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
@@ -16178,6 +16089,15 @@
         "url": "https://opencollective.com/lint-staged"
       }
     },
+    "node_modules/lint-staged/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lint-staged/node_modules/chalk": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
@@ -16189,6 +16109,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/lint-staged/node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
     },
     "node_modules/lint-staged/node_modules/commander": {
       "version": "10.0.1",
@@ -16251,6 +16177,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lint-staged/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lint-staged/node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -16258,6 +16193,49 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/listr2": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.8.tgz",
+      "integrity": "sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==",
+      "dev": true,
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "colorette": "^2.0.19",
+        "log-update": "^4.0.0",
+        "p-map": "^4.0.0",
+        "rfdc": "^1.3.0",
+        "rxjs": "^7.8.0",
+        "through": "^2.3.8",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "enquirer": ">= 2.3.0 < 3"
+      },
+      "peerDependenciesMeta": {
+        "enquirer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lint-staged/node_modules/listr2/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16323,23 +16301,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lint-staged/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lint-staged/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/lint-staged/node_modules/yaml": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/listr2": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.8.tgz",
-      "integrity": "sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
       "dev": true,
       "dependencies": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.19",
+        "colorette": "^2.0.16",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.8.0",
+        "rxjs": "^7.5.5",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=12"
       },
       "peerDependencies": {
         "enquirer": ">= 2.3.0 < 3"
@@ -17359,6 +17377,14 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
+    },
+    "node_modules/node-persist": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-3.1.3.tgz",
+      "integrity": "sha512-CaFv+kSZtsc+VeDRldK1yR47k1vPLBpzYB9re2z7LIwITxwBtljMq3s8VQnnr+x3E8pQfHbc5r2IyJsBLJhtXg==",
+      "engines": {
+        "node": ">=10.12.0"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.6",
@@ -20562,12 +20588,12 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true,
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/yaml-ast-parser": {
@@ -27412,9 +27438,9 @@
       }
     },
     "@colony/colony-js": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.1.0.tgz",
-      "integrity": "sha512-t4x3IOjyT+fxz6EIoQ4073N7cumPwb0GYwoaYUvJZlJtMzOm5tk8oFvE6puYaQjlsmHMU/VJvvWVZlJ1GIPzoQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-6.3.6.tgz",
+      "integrity": "sha512-vfmby0kKiwKjmBt1O/YD5iv8SGVebHg5DucTYYleW6gc7I5VtMonlgFCwGEwWtgPZWEgvJskDUcya/bZYrTBTg==",
       "requires": {
         "cross-fetch": "^3.1.5"
       }
@@ -27882,22 +27908,6 @@
         "yargs": "^17.0.0"
       },
       "dependencies": {
-        "astral-regex": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-          "dev": true
-        },
-        "cli-truncate": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-          "dev": true,
-          "requires": {
-            "slice-ansi": "^3.0.0",
-            "string-width": "^4.2.0"
-          }
-        },
         "cliui": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -27908,12 +27918,6 @@
             "strip-ansi": "^6.0.1",
             "wrap-ansi": "^7.0.0"
           }
-        },
-        "colorette": {
-          "version": "2.0.20",
-          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-          "dev": true
         },
         "cosmiconfig": {
           "version": "7.1.0",
@@ -27928,28 +27932,6 @@
             "yaml": "^1.10.0"
           }
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "listr2": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-          "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
-          "dev": true,
-          "requires": {
-            "cli-truncate": "^2.1.0",
-            "colorette": "^2.0.16",
-            "log-update": "^4.0.0",
-            "p-map": "^4.0.0",
-            "rfdc": "^1.3.0",
-            "rxjs": "^7.5.5",
-            "through": "^2.3.8",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
         "parse-json": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -27960,17 +27942,6 @@
             "error-ex": "^1.3.1",
             "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
-          }
-        },
-        "slice-ansi": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "astral-regex": "^2.0.0",
-            "is-fullwidth-code-point": "^3.0.0"
           }
         },
         "wrap-ansi": {
@@ -27988,12 +27959,6 @@
           "version": "5.0.8",
           "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
           "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-          "dev": true
-        },
-        "yaml": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
           "dev": true
         },
         "yargs": {
@@ -28202,9 +28167,9 @@
       }
     },
     "@graphql-tools/executor-http": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.9.tgz",
-      "integrity": "sha512-tNzMt5qc1ptlHKfpSv9wVBVKCZ7gks6Yb/JcYJluxZIT4qRV+TtOFjpptfBU63usgrGVOVcGjzWc/mt7KhmmpQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-0.1.10.tgz",
+      "integrity": "sha512-hnAfbKv0/lb9s31LhWzawQ5hghBfHS+gYWtqxME6Rl0Aufq9GltiiLBcl7OVVOnkLF0KhwgbYP1mB5VKmgTGpg==",
       "dev": true,
       "requires": {
         "@graphql-tools/utils": "^9.2.1",
@@ -28240,9 +28205,9 @@
       }
     },
     "@graphql-tools/git-loader": {
-      "version": "7.2.22",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.2.22.tgz",
-      "integrity": "sha512-9rpHggHiOeqA7/ZlKD3c5yXk5bPGw0zkIgKMerjCmFAQAZ6CEVfsa7nAzEWQxn6rpdaBft4/0A56rPMrsUwGBA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-7.3.0.tgz",
+      "integrity": "sha512-gcGAK+u16eHkwsMYqqghZbmDquh8QaO24Scsxq+cVR+vx1ekRlsEiXvu+yXVDbZdcJ6PBIbeLcQbEu+xhDLmvQ==",
       "dev": true,
       "requires": {
         "@graphql-tools/graphql-tag-pluck": "7.5.2",
@@ -28339,9 +28304,9 @@
       }
     },
     "@graphql-tools/merge": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.1.tgz",
-      "integrity": "sha512-hssnPpZ818mxgl5+GfyOOSnnflAxiaTn1A1AojZcIbh4J52sS1Q0gSuBR5VrnUDjuxiqoCotpXdAQl+K+U6KLQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
+      "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
       "dev": true,
       "requires": {
         "@graphql-tools/utils": "^9.2.1",
@@ -28358,9 +28323,9 @@
       }
     },
     "@graphql-tools/prisma-loader": {
-      "version": "7.2.71",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.71.tgz",
-      "integrity": "sha512-FuIvhRrkduqPdj3QX0/anCxGViEETfoZ/1NvotfM6iVO1XxR75VXvP/iyKGbK6XvYRXwSstgj2DetlQnqdgXhA==",
+      "version": "7.2.72",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-7.2.72.tgz",
+      "integrity": "sha512-0a7uV7Fky6yDqd0tI9+XMuvgIo6GAqiVzzzFV4OSLry4AwiQlI3igYseBV7ZVOGhedOTqj/URxjpiv07hRcwag==",
       "dev": true,
       "requires": {
         "@graphql-tools/url-loader": "^7.17.18",
@@ -28372,8 +28337,8 @@
         "debug": "^4.3.1",
         "dotenv": "^16.0.0",
         "graphql-request": "^6.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
+        "http-proxy-agent": "^6.0.0",
+        "https-proxy-agent": "^6.0.0",
         "jose": "^4.11.4",
         "js-yaml": "^4.0.0",
         "json-stable-stringify": "^1.0.1",
@@ -29093,12 +29058,6 @@
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
       "peer": true
     },
-    "@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "dev": true
-    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -29259,6 +29218,15 @@
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+    },
+    "@types/node-persist": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/node-persist/-/node-persist-3.1.3.tgz",
+      "integrity": "sha512-6MdN3tQcBdlnswJ/JGJYEwWh72Ru3RHH3I16PCQ/GB7ecM3YFfcUB4Yysim6HHnKbCse5vgk5r51JKR7w5zE0Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -29622,12 +29590,12 @@
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.0.1.tgz",
+      "integrity": "sha512-V9to8gr2GK7eA+xskWGAFUX/TLSQKuH2TI06c/jGLL6yLp3oEjtnqM7a5tPV9fC1rabLeAgThZeBwsYX+WWHpw==",
       "dev": true,
       "requires": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "dependencies": {
         "debug": {
@@ -32514,14 +32482,13 @@
       }
     },
     "http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-6.0.1.tgz",
+      "integrity": "sha512-rD8wrfJHbnVll9lkIpQH3vDbKON1Ssciggwydom/r89HLBXEqdMhL6wx7QF5WePDPSr0OdoztdXoojbrXadG5Q==",
       "dev": true,
       "requires": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.0.1",
+        "debug": "^4.3.4"
       },
       "dependencies": {
         "debug": {
@@ -32542,12 +32509,12 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-6.1.0.tgz",
+      "integrity": "sha512-rvGRAlc3y+iS7AC9Os2joN91mX8wHpJ4TEklmHHxr7Gz2Juqa7fJmJ8wWxXNpTaRt56MQTwojxV5d82UW/+jwg==",
       "dev": true,
       "requires": {
-        "agent-base": "6",
+        "agent-base": "^7.0.1",
         "debug": "4"
       },
       "dependencies": {
@@ -33517,10 +33484,22 @@
         "yaml": "^2.2.2"
       },
       "dependencies": {
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+          "dev": true
+        },
         "chalk": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
           "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+          "dev": true
+        },
+        "colorette": {
+          "version": "2.0.20",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+          "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
           "dev": true
         },
         "commander": {
@@ -33561,11 +33540,45 @@
           "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
           "dev": true
         },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
         "is-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
           "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
           "dev": true
+        },
+        "listr2": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.8.tgz",
+          "integrity": "sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==",
+          "dev": true,
+          "requires": {
+            "cli-truncate": "^2.1.0",
+            "colorette": "^2.0.19",
+            "log-update": "^4.0.0",
+            "p-map": "^4.0.0",
+            "rfdc": "^1.3.0",
+            "rxjs": "^7.8.0",
+            "through": "^2.3.8",
+            "wrap-ansi": "^7.0.0"
+          },
+          "dependencies": {
+            "cli-truncate": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+              "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+              "dev": true,
+              "requires": {
+                "slice-ansi": "^3.0.0",
+                "string-width": "^4.2.0"
+              }
+            }
+          }
         },
         "mimic-fn": {
           "version": "4.0.0",
@@ -33602,21 +33615,49 @@
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
           "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
           "dev": true
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yaml": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+          "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+          "dev": true
         }
       }
     },
     "listr2": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.8.tgz",
-      "integrity": "sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
+      "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
       "dev": true,
       "requires": {
         "cli-truncate": "^2.1.0",
-        "colorette": "^2.0.19",
+        "colorette": "^2.0.16",
         "log-update": "^4.0.0",
         "p-map": "^4.0.0",
         "rfdc": "^1.3.0",
-        "rxjs": "^7.8.0",
+        "rxjs": "^7.5.5",
         "through": "^2.3.8",
         "wrap-ansi": "^7.0.0"
       },
@@ -34429,6 +34470,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
       "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
+    },
+    "node-persist": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/node-persist/-/node-persist-3.1.3.tgz",
+      "integrity": "sha512-CaFv+kSZtsc+VeDRldK1yR47k1vPLBpzYB9re2z7LIwITxwBtljMq3s8VQnnr+x3E8pQfHbc5r2IyJsBLJhtXg=="
     },
     "node-releases": {
       "version": "2.0.6",
@@ -36893,9 +36939,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yaml-ast-parser": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "ethers": "^5.7.2",
     "express": "^4.18.2",
     "fs-extra": "^10.1.0",
-    "graphql": "^16.6.0"
+    "graphql": "^16.6.0",
+    "node-persist": "^3.1.3"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "^3.3.1",
@@ -41,6 +42,7 @@
     "@types/express": "^4.17.14",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^18.11.9",
+    "@types/node-persist": "^3.1.3",
     "@typescript-eslint/eslint-plugin": "^5.42.0",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.8.0",

--- a/src/blockListener.ts
+++ b/src/blockListener.ts
@@ -1,14 +1,11 @@
 import networkClient from './networkClient';
-import { verbose, writeJsonStats } from './utils';
+import { updateStats, verbose } from './utils';
 import { EthersObserverEvents } from './types';
 
 const blockListener = (): typeof networkClient.provider =>
-  networkClient.provider.on(
-    EthersObserverEvents.Block,
-    async (blockNumber) => {
-      verbose('Processing block #', blockNumber);
-      await writeJsonStats({ latestBlock: blockNumber });
-    },
-  );
+  networkClient.provider.on(EthersObserverEvents.Block, async (blockNumber) => {
+    verbose('Processing block #', blockNumber);
+    await updateStats({ latestBlock: blockNumber });
+  });
 
 export default blockListener;

--- a/src/handlers/colonies/colonyAdded.ts
+++ b/src/handlers/colonies/colonyAdded.ts
@@ -1,7 +1,7 @@
 import { colonySpecificEventsListener } from '~eventListener';
 import { coloniesSet } from '~trackColonies';
 import { ContractEvent } from '~types';
-import { output, writeJsonStats } from '~utils';
+import { output, updateStats } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { colonyAddress, token: tokenAddress } = event.args ?? {};
@@ -10,7 +10,7 @@ export default async (event: ContractEvent): Promise<void> => {
    * Add it to the Set
    */
   coloniesSet.add(JSON.stringify({ colonyAddress, tokenAddress }));
-  await writeJsonStats({ trackedColonies: coloniesSet.size });
+  await updateStats({ trackedColonies: coloniesSet.size });
 
   output(
     'Found new Colony:',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,53 +1,17 @@
-import express, { Request, Response } from 'express';
-import { Server } from 'http';
 import dotenv from 'dotenv';
 import { utils } from 'ethers';
 
-import blockListener from './blockListener';
-import trackColonies from './trackColonies';
-import eventListener from './eventListener';
-import amplifyClientSetup from './amplifyClient';
-import provider, { getChainId } from './provider';
-import { output, readJsonStats } from './utils';
-import trackExtensions from './trackExtensions';
-import trackNetworkInverseFee from './trackNetworkInverseFee';
+import blockListener from '~blockListener';
+import trackColonies from '~trackColonies';
+import eventListener from '~eventListener';
+import amplifyClientSetup from '~amplifyClient';
+import { initialiseProvider } from '~provider';
+import trackExtensions from '~trackExtensions';
+import trackNetworkInverseFee from '~trackNetworkInverseFee';
+import { startStatsServer } from '~stats';
 
 dotenv.config();
 utils.Logger.setLogLevel(utils.Logger.levels.ERROR);
-
-const app = express();
-const port = process.env.STATS_PORT;
-
-app.get('/', (req: Request, res: Response) => {
-  res
-    .type('text/plain')
-    .send(process.env.NODE_ENV !== 'production' ? 'Block Ingestor' : '');
-});
-
-/*
- * Use to check if service is alive
- */
-app.get('/liveness', (req, res) => res.sendStatus(200));
-
-/*
- * Use to check various service stats
- */
-app.get('/stats', (req, res) => {
-  readJsonStats().then((stats) => res.type('json').send(stats));
-});
-
-const startStatsServer = async (): Promise<Server> =>
-  app.listen(port, async () => {
-    /*
-     * Need to run this first, otherwise it won't set the chain internally
-     * Maybe a good idea would be to refactor this store the network inside the provider
-     * so that way we'll fetch it on provider initialization
-     */
-    await provider.getNetwork();
-    output('Block Ingestor started on chain', getChainId());
-    output(`Stats available at http://localhost:${port}/stats`);
-    output(`Liveness check available at http://localhost:${port}/liveness`);
-  });
 
 const startIngestor = async (): Promise<void> => {
   /*
@@ -72,9 +36,8 @@ const startIngestor = async (): Promise<void> => {
 };
 
 const start = async (): Promise<void> => {
-  if (port) {
-    await startStatsServer();
-  }
+  await initialiseProvider();
+  await startStatsServer();
   startIngestor();
   amplifyClientSetup();
 };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -7,15 +7,16 @@ dotenv.config();
 
 let chainId: ChainID;
 
-export const setChainId = (newChainId: number): void => { chainId = newChainId; };
+export const setChainId = (newChainId: number): void => {
+  chainId = newChainId;
+};
 export const getChainId = (): ChainID => chainId;
 
 const provider = new providers.JsonRpcProvider(process.env.CHAIN_RPC_ENDPOINT);
 
-provider.getNetwork().then(
-  ({ chainId: currentChainId }) => {
-    setChainId(currentChainId);
-  },
-);
+export const initialiseProvider = async (): Promise<void> => {
+  const { chainId } = await provider.getNetwork();
+  setChainId(chainId);
+};
 
 export default provider;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,37 @@
+import express from 'express';
+
+import { output, readJsonStats } from '~utils';
+import { getChainId } from '~provider';
+
+const app = express();
+const port = process.env.STATS_PORT;
+
+app.get('/', (_, res) => {
+  res
+    .type('text/plain')
+    .send(process.env.NODE_ENV !== 'production' ? 'Block Ingestor' : '');
+});
+
+/*
+ * Use to check if service is alive
+ */
+app.get('/liveness', (_, res) => res.sendStatus(200));
+
+/*
+ * Use to check various service stats
+ */
+app.get('/stats', (_, res) => {
+  readJsonStats().then((stats) => res.type('json').send(stats));
+});
+
+export const startStatsServer = async (): Promise<void> => {
+  if (!port) {
+    return;
+  }
+
+  app.listen(port, async () => {
+    output('Block Ingestor started on chain', getChainId());
+    output(`Stats available at http://localhost:${port}/stats`);
+    output(`Liveness check available at http://localhost:${port}/liveness`);
+  });
+};

--- a/src/trackColonies.ts
+++ b/src/trackColonies.ts
@@ -4,11 +4,11 @@ import { getLogs } from '@colony/colony-js';
 import networkClient from '~networkClient';
 import {
   output,
-  writeJsonStats,
   verbose,
   addNetworkEventListener,
   setToJS,
   toNumber,
+  updateStats,
 } from '~utils';
 import { colonySpecificEventsListener } from '~eventListener';
 import { ContractEventsSignatures } from '~types';
@@ -50,7 +50,7 @@ export default async (): Promise<void> => {
     colonies.add(JSON.stringify({ colonyAddress, tokenAddress }));
   });
 
-  await writeJsonStats({ trackedColonies: colonies.size });
+  await updateStats({ trackedColonies: colonies.size });
 
   output('Tracking', colonies.size, 'currently deployed colonies');
 

--- a/src/trackColonyActions.ts
+++ b/src/trackColonyActions.ts
@@ -14,7 +14,12 @@ import {
 } from '~handlers';
 import networkClient from '~networkClient';
 import { ColonyActionHandler, ContractEventsSignatures, Filter } from '~types';
-import { getCachedColonyClient, mapLogToContractEvent, verbose } from '~utils';
+import {
+  getCachedColonyClient,
+  getLatestBlock,
+  mapLogToContractEvent,
+  verbose,
+} from '~utils';
 
 const getFilter = (
   eventSignature: ContractEventsSignatures,
@@ -38,7 +43,9 @@ const trackActionsByEvent = async (
 ): Promise<void> => {
   const colonyClient = await getCachedColonyClient(colonyAddress);
   const filter = getFilter(eventSignature, colonyAddress);
-  const logs = await getLogs(networkClient, filter);
+  const logs = await getLogs(networkClient, filter, {
+    fromBlock: await getLatestBlock(),
+  });
   logs.forEach(async (log) => {
     const event = await mapLogToContractEvent(log, colonyClient.interface);
     if (!event) {

--- a/src/trackExtensions.ts
+++ b/src/trackExtensions.ts
@@ -4,6 +4,7 @@ import networkClient from '~networkClient';
 import {
   deleteExtensionFromEvent,
   getCachedColonyClient,
+  getLatestBlock,
   isExtensionDeprecated,
   isExtensionInitialised,
   mapLogToContractEvent,
@@ -16,8 +17,7 @@ import { SUPPORTED_EXTENSION_IDS } from '~constants';
 import { extensionSpecificEventsListener } from '~eventListener';
 
 export default async (): Promise<void> => {
-  // @TODO: Set to the latest block processed by block-ingestor
-  const latestBlock = 1;
+  const latestBlock = await getLatestBlock();
 
   SUPPORTED_EXTENSION_IDS.forEach(async (extensionId) => {
     verbose(

--- a/stats/446501053769c06c565094b26d26e8ef
+++ b/stats/446501053769c06c565094b26d26e8ef
@@ -1,1 +1,0 @@
-{"key":"stats","value":{"trackedColonies":5,"latestBlock":1039}}

--- a/stats/446501053769c06c565094b26d26e8ef
+++ b/stats/446501053769c06c565094b26d26e8ef
@@ -1,0 +1,1 @@
+{"key":"stats","value":{"trackedColonies":5,"latestBlock":1039}}


### PR DESCRIPTION
This optimisation allows block-ingestor to pick up right where it left off before restart, rather than having to go from block 1. It uses `node-persist` library for easier persistent storage (which still uses JSON files, but has a nicer interface)

### Testing
I imagine this approach will only get tested property in the QA environment, but for now:
1. Run the ingestor on this branch separately
2. Run the `temp-create-data` script in CDapp
3. Restart the ingestor. On `master`, you'd see a bunch of failed mutations related to extensions and actions. On this branch, there shouldn't be more than 1-2 failed mutations (I suspect these are due to ganache/block-ingestor replaying some of the transactions)

TODO: 
- [x] Refactor stats to use `node-persist`
- [x] Track extensions from latest processed block
- [x] Track actions from latest processed block