### PR TITLE
Set initiatorAddress to AddressZero

### DIFF
--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 
 import { ContractEvent, MotionEvents } from '~types';
 import { getVotingClient } from '~utils';
@@ -67,6 +67,7 @@ export default async (event: ContractEvent): Promise<void> => {
     const updatedMessages = [
       ...messages,
       {
+        initiatorAddress: constants.AddressZero,
         name: MotionEvents.MotionFinalized,
         messageKey: getMessageKey(transactionHash, logIndex),
       },

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 import {
   MotionStakes,
   UserStakes,
@@ -265,6 +265,7 @@ export const getUpdatedMessages = ({
     updatedMessages.push({
       name: MotionEvents.MotionVotingPhase,
       messageKey: `${messageKey}_${MotionEvents.MotionVotingPhase}`,
+      initiatorAddress: constants.AddressZero,
     });
   }
 


### PR DESCRIPTION
[colonyCDapp#520](https://github.com/JoinColony/colonyCDapp/pull/520) makes initiatorAddress required with the change when refactoring motion messages to be a model

Currently SystemMessages do not have an initiatorAddress set, this PR will set initiatorAddress to AddressZero

Contributes to colonyCDapp#423