### PR TITLE
Add missing `fromDomainId` to `mintTokens` handler

### DIFF
--- a/src/handlers/actions/mintTokens.ts
+++ b/src/handlers/actions/mintTokens.ts
@@ -1,6 +1,12 @@
-import { ColonyActionType } from '~graphql';
+import { Id } from '@colony/colony-js';
+
 import { ContractEvent } from '~types';
-import { writeActionFromEvent, getColonyTokenAddress } from '~utils';
+import {
+  writeActionFromEvent,
+  getColonyTokenAddress,
+  getDomainDatabaseId,
+} from '~utils';
+import { ColonyActionType } from '~graphql';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { contractAddress: colonyAddress } = event;
@@ -14,5 +20,6 @@ export default async (event: ContractEvent): Promise<void> => {
     recipientAddress,
     amount: amount.toString(),
     tokenAddress,
+    fromDomainId: getDomainDatabaseId(colonyAddress, Id.RootDomain),
   });
 };


### PR DESCRIPTION
> The action list item for the mint tokens action is not displaying the team in the meta info, which should be "Root”:
![FireShot Capture 039 - Colony CDapp - qa-cdapp colony io](https://github.com/JoinColony/block-ingestor/assets/18473896/46f82cee-34db-4ba8-a18a-77ce8ded483c)

Found while testing on QA.

To test this, just replace the commit hash in `master`, create a mint tokens action, and check that the meta info of the action list item includes the `Root` domain:

![FireShot Capture 053 - Colony CDapp - localhost](https://github.com/JoinColony/block-ingestor/assets/18473896/01949e13-40e6-4a5d-a2d7-25c0bfe0c4d1)
