### PR TITLE
Wire Manage Tokens / Edit Colony motion

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -131,6 +131,27 @@ export const mutations = {
       }
     }
   `,
+  updateColonyMetadata: /* GraphQL */ `
+    mutation UpdateColonyMetadata($input: UpdateColonyMetadataInput!) {
+      updateColonyMetadata(input: $input) {
+        id
+      }
+    }
+  `,
+  createColonyTokens: /* GraphQL */ `
+    mutation CreateColonyTokens($input: CreateColonyTokensInput!) {
+      createColonyTokens(input: $input) {
+        id
+      }
+    }
+  `,
+  deleteColonyTokens: /* GraphQL */ `
+    mutation DeleteColonyTokens($input: DeleteColonyTokensInput!) {
+      deleteColonyTokens(input: $input) {
+        id
+      }
+    }
+  `,
 };
 
 /*
@@ -283,6 +304,26 @@ export const queries = {
               newDescription
             }
           }
+          pendingColonyMetadata {
+            id
+            displayName
+            avatar
+            thumbnail
+            changelog {
+              transactionHash
+              oldDisplayName
+              newDisplayName
+              hasAvatarChanged
+              hasWhitelistChanged
+              haveTokensChanged
+            }
+            isWhitelistActivated
+            whitelistedAddresses
+            modifiedTokenAddresses {
+              added
+              removed
+            }
+          }
         }
       }
     }
@@ -298,6 +339,52 @@ export const queries = {
       ) {
         items {
           id
+        }
+      }
+    }
+  `,
+  getColonyMetadata: /* GraphQL */ `
+    query GetColonyMetadata($id: ID!) {
+      getColonyMetadata(id: $id) {
+        id
+        displayName
+        avatar
+        thumbnail
+        changelog {
+          transactionHash
+          oldDisplayName
+          newDisplayName
+          hasAvatarChanged
+          hasWhitelistChanged
+          haveTokensChanged
+        }
+        isWhitelistActivated
+        whitelistedAddresses
+        modifiedTokenAddresses {
+          added
+          removed
+        }
+      }
+    }
+  `,
+  getTokenFromEverywhere: /* GraphQL */ `
+    query GetTokenFromEverywhere($input: TokenFromEverywhereArguments!) {
+      getTokenFromEverywhere(input: $input) {
+        items {
+          id
+        }
+      }
+    }
+  `,
+  getColony: /* GraphQL */ `
+    query GetColony($id: ID!) {
+      getColony(id: $id) {
+        colonyAddress: id
+        tokens {
+          items {
+            id
+            tokenAddress: tokenID
+          }
         }
       }
     }

--- a/src/handlers/motions/motionCreated/handlers/editColony.ts
+++ b/src/handlers/motions/motionCreated/handlers/editColony.ts
@@ -3,19 +3,17 @@ import { ContractEvent, motionNameMapping } from '~types';
 import { getPendingMetadataDatabaseId } from '~utils';
 import { createMotionInDB } from '../helpers';
 
-export const handleManageDomainMotion = async (
+export const handleEditColonyMotion = async (
   event: ContractEvent,
-  parsedAction: TransactionDescription,
+  { name }: TransactionDescription,
 ): Promise<void> => {
   const { transactionHash, contractAddress: colonyAddress } = event;
-  const { name } = parsedAction;
-  const pendingDomainMetadataId = getPendingMetadataDatabaseId(
+  const pendingColonyMetadataId = getPendingMetadataDatabaseId(
     colonyAddress,
     transactionHash,
   );
-
   await createMotionInDB(event, {
     type: motionNameMapping[name],
-    pendingDomainMetadataId,
+    pendingColonyMetadataId,
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/index.ts
+++ b/src/handlers/motions/motionCreated/handlers/index.ts
@@ -5,3 +5,4 @@ export { handleUnlockTokenMotion } from './unlockToken';
 export { handlePaymentMotion } from './payment';
 export { handleMoveFundsMotion } from './moveFunds';
 export { handleDomainEditReputationMotion } from './reputation';
+export { handleEditColonyMotion } from './editColony';

--- a/src/handlers/motions/motionCreated/motionCreated.ts
+++ b/src/handlers/motions/motionCreated/motionCreated.ts
@@ -12,6 +12,7 @@ import {
   handlePaymentMotion,
   handleMoveFundsMotion,
   handleDomainEditReputationMotion,
+  handleEditColonyMotion,
 } from './handlers';
 
 export default async (event: ContractEvent): Promise<void> => {
@@ -67,6 +68,11 @@ export default async (event: ContractEvent): Promise<void> => {
       case ColonyOperations.EmitDomainReputationReward:
       case ColonyOperations.EmitDomainReputationPenalty: {
         await handleDomainEditReputationMotion(event, parsedAction);
+        break;
+      }
+
+      case ColonyOperations.EditColony: {
+        await handleEditColonyMotion(event, parsedAction);
         break;
       }
 

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -9,7 +9,12 @@ import {
   updateMotionInDB,
   getMessageKey,
 } from '../helpers';
-import { getStakerReward, linkPendingDomainMetadataWithDomain } from './helpers';
+
+import {
+  getStakerReward,
+  linkPendingColonyMetadataWithColony,
+  linkPendingDomainMetadataWithDomain,
+} from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
@@ -45,7 +50,9 @@ export default async (event: ContractEvent): Promise<void> => {
       motionData,
     } = finalizedMotion;
 
-    const yayWon = BigNumber.from(yayVotes).gt(nayVotes) || (Number(yayPercentage) > Number(nayPercentage));
+    const yayWon =
+      BigNumber.from(yayVotes).gt(nayVotes) ||
+      Number(yayPercentage) > Number(nayPercentage);
 
     /*
      * pendingDomainMetadata is a motion data prop that we use to store the metadata of a Domain that COULD be created/edited
@@ -54,7 +61,18 @@ export default async (event: ContractEvent): Promise<void> => {
      * a new DomainMetadata with the corresponding Domain item id.
      */
     if (finalizedMotion.pendingDomainMetadata && yayWon) {
-      await linkPendingDomainMetadataWithDomain(action, colonyAddress, finalizedMotion);
+      await linkPendingDomainMetadataWithDomain(
+        action,
+        colonyAddress,
+        finalizedMotion,
+      );
+    }
+
+    if (finalizedMotion.pendingColonyMetadata && yayWon) {
+      await linkPendingColonyMetadataWithColony(
+        finalizedMotion.pendingColonyMetadata,
+        colonyAddress,
+      );
     }
 
     const updatedStakerRewards = await Promise.all(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,7 @@ export enum ColonyActionType {
   MoveFundsMotion = 'MOVE_FUNDS_MOTION',
   EmitDomainReputationPenaltyMotion = 'EMIT_DOMAIN_REPUTATION_PENALTY_MOTION',
   EmitDomainReputationRewardMotion = 'EMIT_DOMAIN_REPUTATION_REWARD_MOTION',
+  ColonyEditMotion = 'COLONY_EDIT_MOTION',
 }
 
 export type ColonyActionHandler = (event: ContractEvent) => Promise<void>;
@@ -135,4 +136,17 @@ interface VotingReputationParams {
   submitPeriod: string;
   revealPeriod: string;
   escalationPeriod: string;
+}
+
+export interface ColonyQuery {
+  colonyAddress: string;
+  tokens:
+    | {
+        items: Array<{
+          id: string;
+          tokenAddress: string;
+        } | null>;
+      }
+    | null
+    | undefined;
 }

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -23,6 +23,7 @@ export enum ColonyOperations {
   MoveFundsBetweenPots = 'moveFundsBetweenPots',
   EmitDomainReputationPenalty = 'emitDomainReputationPenalty',
   EmitDomainReputationReward = 'emitDomainReputationReward',
+  EditColony = 'editColony',
 }
 
 export enum MotionEvents {
@@ -51,7 +52,7 @@ export const motionNameMapping: { [key: string]: ColonyActionType } = {
   [ColonyOperations.UnlockToken]: ColonyActionType.UnlockTokenMotion,
   // addDomain: ColonyMotions.CreateDomainMotion,
   // editDomain: ColonyMotions.EditDomainMotion,
-  // editColony: ColonyMotions.ColonyEditMotion,
+  [ColonyOperations.EditColony]: ColonyActionType.ColonyEditMotion,
   // setUserRoles: ColonyMotions.SetUserRolesMotion,
   [ColonyOperations.MoveFundsBetweenPots]: ColonyActionType.MoveFundsMotion,
   [ColonyOperations.Upgrade]: ColonyActionType.VersionUpgradeMotion,
@@ -83,7 +84,7 @@ export interface MotionStateHistory {
   hasPassed: boolean;
   hasFailed: boolean;
   hasFailedNotFinalizable: boolean;
-  inRevealPhase: boolean
+  inRevealPhase: boolean;
 }
 
 export interface MotionData {
@@ -156,11 +157,32 @@ interface DomainMetadata {
   changelog: [DomainMetadataChangelog];
 }
 
+interface ColonyMetadataChangelog {
+  transactionHash: string;
+  oldDisplayName: string;
+  newDisplayName: string;
+  hasAvatarChanged: boolean;
+  hasWhitelistChanged: boolean;
+  haveTokensChanged: boolean;
+}
+
+export interface ColonyMetadata {
+  id: string;
+  displayName: string;
+  avatar?: string;
+  thumbnail?: string;
+  changelog?: ColonyMetadataChangelog[];
+  isWhitelistActivated?: boolean;
+  whitelistedAddresses?: string[];
+  modifiedTokenAddresses?: string[];
+}
+
 export interface MotionQuery {
   id: string;
   motionData: MotionData;
   createdAt: string;
   pendingDomainMetadata: DomainMetadata;
+  pendingColonyMetadata: ColonyMetadata;
 }
 
 export interface MotionMessage {

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -166,6 +166,11 @@ interface ColonyMetadataChangelog {
   haveTokensChanged: boolean;
 }
 
+export interface PendingModifiedTokenAddresses {
+  added: string[];
+  removed: string[];
+}
+
 export interface ColonyMetadata {
   id: string;
   displayName: string;
@@ -174,7 +179,7 @@ export interface ColonyMetadata {
   changelog?: ColonyMetadataChangelog[];
   isWhitelistActivated?: boolean;
   whitelistedAddresses?: string[];
-  modifiedTokenAddresses?: string[];
+  modifiedTokenAddresses?: PendingModifiedTokenAddresses;
 }
 
 export interface MotionQuery {

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,0 +1,1 @@
+export const notNull = <T>(item: T | null): item is T => item !== null;

--- a/src/utils/colonyClient.ts
+++ b/src/utils/colonyClient.ts
@@ -1,6 +1,8 @@
 import { AnyColonyClient } from '@colony/colony-js';
 
+import { query } from '~amplifyClient';
 import networkClient from '~networkClient';
+import { ColonyQuery } from '~types';
 
 const colonyClientsCache: Record<string, AnyColonyClient> = {};
 
@@ -18,4 +20,21 @@ export const getCachedColonyClient = async (
   const colonyClient = await networkClient.getColonyClient(colonyAddress);
   colonyClientsCache[colonyAddress] = colonyClient;
   return colonyClient;
+};
+
+export const getColonyFromDB = async (
+  colonyAddress: string,
+): Promise<ColonyQuery | undefined> => {
+  const colony = await query<ColonyQuery>('getColony', {
+    id: colonyAddress,
+  });
+
+  if (!colony) {
+    console.error(
+      `Could not find colony: ${colonyAddress} in database. This is a bug and should be investigated.`,
+    );
+    return;
+  }
+
+  return colony;
 };

--- a/src/utils/domains.ts
+++ b/src/utils/domains.ts
@@ -3,8 +3,7 @@ export const getDomainDatabaseId = (
   nativeId: number,
 ): string => `${colonyAddress}_${nativeId}`;
 
-export const getPendingMotionDomainDatabaseId = (
+export const getPendingMetadataDatabaseId = (
   colonyAddress: string,
   transactionHash: string,
-) => `${colonyAddress}_motion-${transactionHash}`;
-
+): string => `${colonyAddress}_motion-${transactionHash}`;

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,4 +1,8 @@
+import { mutate, query } from '~amplifyClient';
+import { ColonyQuery, PendingModifiedTokenAddresses } from '~types';
+
 import { getCachedColonyClient } from './colonyClient';
+import { notNull } from './arrays';
 
 export const getColonyTokenAddress = async (
   colonyAddress: string,
@@ -6,4 +10,60 @@ export const getColonyTokenAddress = async (
   const colonyClient = await getCachedColonyClient(colonyAddress);
   const tokenAddress = await colonyClient.getToken();
   return tokenAddress;
+};
+
+export const getExistingTokenAddresses = (colony: ColonyQuery): string[] =>
+  colony.tokens?.items
+    .map((tokenItem) => tokenItem?.tokenAddress)
+    .filter((item): item is string => !!item) ?? [];
+
+export const updateColonyTokens = async (
+  colony: ColonyQuery,
+  existingTokenAddresses: string[],
+  { added, removed }: PendingModifiedTokenAddresses,
+): Promise<void> => {
+  const currentAddresses = new Set(existingTokenAddresses);
+  added.forEach(async (tokenAddress) => {
+    if (!currentAddresses.has(tokenAddress)) {
+      /**
+       * Call the GetTokenFromEverywhere query to ensure the token
+       * gets added to the DB if it doesn't already exist
+       */
+      const response = await query('getTokenFromEverywhere', {
+        input: {
+          tokenAddress,
+        },
+      });
+
+      /**
+       * Only create colony/token entry in the DB if the token data was returned by the GetTokenFromEverywhereQuery.
+       * Otherwise, it will cause any query referencing it to fail
+       */
+      if (response?.items?.length) {
+        await mutate('createColonyTokens', {
+          input: {
+            colonyID: colony.colonyAddress,
+            tokenID: tokenAddress,
+          },
+        });
+      }
+    }
+  });
+
+  removed.forEach(async (tokenAddress) => {
+    // get the ID of the colony/token entry in the DB (this is separate from token or colony address)
+    const { id: colonyTokenId } =
+      colony.tokens?.items
+        .filter(notNull)
+        .find(({ tokenAddress: address }) => address === tokenAddress) ?? {};
+
+    // If we can't find it, e.g. because it has already been removed by another motion, do nothing.
+    if (colonyTokenId) {
+      await mutate('deleteColonyTokens', {
+        input: {
+          id: colonyTokenId,
+        },
+      });
+    }
+  });
 };


### PR DESCRIPTION
This PR adds support for the manage tokens motion. Test with https://github.com/JoinColony/colonyCDapp/pull/553.

It works the same as Domains.

In the editColonyMotion saga, we create a "pending" colonyMetadata object that represents the intended state change.

When a successful motion is finalized, we update the actual colony metadata with the changes, and update the colony tokens if needed. 

Note that I've implented this so that, in theory, we won't be overwriting metadata state changes that occurred after the motion was created (as currently happens with the domain metadata). I have only been able to test that this is true for adding / removing tokens as other colonyEditMotion functionality is yet to be wired (this should also be tested then).
