### PR TITLE
Refactor updating domain metadata on motion finalized

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -389,6 +389,25 @@ export const queries = {
       }
     }
   `,
+  getDomainMetadata: /* GraphQL */ `
+    query GetDomainMetadata($id: ID!) {
+      getDomainMetadata(id: $id) {
+        color
+        description
+        id
+        name
+        changelog {
+          newColor
+          newDescription
+          newName
+          oldColor
+          oldDescription
+          oldName
+          transactionHash
+        }
+      }
+    }
+  `,
 };
 
 export default (): void => {

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -64,7 +64,7 @@ export default async (event: ContractEvent): Promise<void> => {
       await linkPendingDomainMetadataWithDomain(
         action,
         colonyAddress,
-        finalizedMotion,
+        finalizedMotion.pendingDomainMetadata,
       );
     }
 

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -149,12 +149,12 @@ interface DomainMetadataChangelog {
   newDescription: string;
 }
 
-interface DomainMetadata {
+export interface DomainMetadata {
   id: string;
   name: string;
   description: string;
-  color: string;
-  changelog: [DomainMetadataChangelog];
+  color: DomainColor;
+  changelog?: DomainMetadataChangelog[];
 }
 
 interface ColonyMetadataChangelog {


### PR DESCRIPTION
This pr ensures that only the domain metadata that was changed by a motion gets updated in the database. 

Previously, the behaviour was updating the entire domain metadata state with the entire pendingMetadata state, which meant that any changes occuring to the domain metadata after the motion was created, even ones that were not explicitly changed by the motion, would be overwritten.

For example:

Motion 1 created: changes color from to blue to green
Motion 2 created: changes description. Doesn't change color at all.
Motion 1 finalizes, and color changes to green.
Motion 2 finalizes, and changes color back to blue, because that was the color when Motion 2 was created. Expected behaviour would be to leave color alone, because the motion didn't change the color of the domain, only the description.

To test:
Run block ingestor separately on this commit.
Go to CDapp and test the flow above. 

Now, finalizing motion 2 shouldn't affect the domain's color. The final state should be color green, with the updated description (i.e. both changes are persisted simulataneously). 