### PR TITLE
Add unclaimed stakes support

### DIFF
--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -403,7 +403,6 @@ export const queries = {
           }
         }
         motionsWithUnclaimedStakes {
-          transactionHash
           motionId
           unclaimedRewards {
             address

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -402,6 +402,15 @@ export const queries = {
             tokenAddress: tokenID
           }
         }
+        unclaimedStakes {
+          transactionHash
+          databaseMotionId
+          unclaimedRewards {
+            address
+            rewards
+            isClaimed
+          }
+        }
       }
     }
   `,

--- a/src/amplifyClient.ts
+++ b/src/amplifyClient.ts
@@ -402,12 +402,15 @@ export const queries = {
             tokenAddress: tokenID
           }
         }
-        unclaimedStakes {
+        motionsWithUnclaimedStakes {
           transactionHash
-          databaseMotionId
+          motionId
           unclaimedRewards {
             address
-            rewards
+            rewards {
+              yay
+              nay
+            }
             isClaimed
           }
         }

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -296,14 +296,12 @@ export const linkPendingMetadata = async (
 
 export const updateColonyUnclaimedStakes = async (
   colonyAddress: string,
-  motionTxHash: string,
   motionDatabaseId: string,
   updatedStakerRewards: StakerReward[],
 ): Promise<void> => {
   const colony = await getColonyFromDB(colonyAddress);
   if (colony) {
     const unclaimedMotionStake = {
-      transactionHash: motionTxHash,
       motionId: motionDatabaseId,
       unclaimedRewards: updatedStakerRewards,
     };

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -1,8 +1,7 @@
 import { BigNumber, constants } from 'ethers';
 
 import { ContractEvent, MotionEvents } from '~types';
-import { getColonyFromDB, getVotingClient } from '~utils';
-import { mutate } from '~amplifyClient';
+import { getVotingClient } from '~utils';
 
 import {
   getMotionDatabaseId,
@@ -11,7 +10,11 @@ import {
   getMessageKey,
 } from '../helpers';
 
-import { getStakerReward, linkPendingMetadata } from './helpers';
+import {
+  getStakerReward,
+  linkPendingMetadata,
+  updateColonyUnclaimedStakes,
+} from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
@@ -72,21 +75,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     await updateMotionInDB(updatedMotionData, newMotionMessages);
 
-    const colony = await getColonyFromDB(colonyAddress);
-    const unclaimedMotionStake = {
-      transactionHash: finalizedMotion.id,
-      motionId: motionDatabaseId,
-      unclaimedRewards: updatedStakerRewards,
-    };
-
-    await mutate('updateColony', {
-      input: {
-        id: colonyAddress,
-        unclaimedStakes: [
-          ...(colony?.unclaimedStakes ?? []),
-          unclaimedMotionStake,
-        ],
-      },
-    });
+    await updateColonyUnclaimedStakes(
+      colonyAddress,
+      finalizedMotion.id,
+      motionDatabaseId,
+      updatedStakerRewards,
+    );
   }
 };

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -77,7 +77,6 @@ export default async (event: ContractEvent): Promise<void> => {
 
     await updateColonyUnclaimedStakes(
       colonyAddress,
-      finalizedMotion.id,
       motionDatabaseId,
       updatedStakerRewards,
     );

--- a/src/handlers/motions/motionRewardClaimed/helpers.ts
+++ b/src/handlers/motions/motionRewardClaimed/helpers.ts
@@ -19,6 +19,7 @@ export const updateColonyUnclaimedStakes = async (
         ({ isClaimed }) => !isClaimed,
       );
 
+      /* If we still have some unclaimed stakes, update the array */
       if (unclaimedRewards.length) {
         motionWithUnclaimedStakes.unclaimedRewards = unclaimedRewards;
         await mutate('updateColony', {

--- a/src/handlers/motions/motionRewardClaimed/helpers.ts
+++ b/src/handlers/motions/motionRewardClaimed/helpers.ts
@@ -1,0 +1,36 @@
+import { mutate } from '~amplifyClient';
+import { getColonyFromDB } from '~utils';
+
+export const updateColonyUnclaimedStakes = async (
+  colonyAddress: string,
+  motionId: string,
+  staker: string,
+): Promise<void> => {
+  const colony = await getColonyFromDB(colonyAddress);
+  const updatedUnclaimedStakes = colony?.unclaimedStakes?.map(
+    (unclaimedStake) => {
+      const { transactionHash } = unclaimedStake;
+
+      if (motionId !== transactionHash) {
+        return unclaimedStake;
+      }
+
+      /* Remove rewards that have been claimed by this staker */
+      const updatedUnclaimedRewards = unclaimedStake?.unclaimedRewards.filter(
+        ({ address }) => address !== staker,
+      );
+
+      return {
+        ...unclaimedStake,
+        unclaimedRewards: updatedUnclaimedRewards,
+      };
+    },
+  );
+
+  await mutate('updateColony', {
+    input: {
+      id: colonyAddress,
+      unclaimedStakes: updatedUnclaimedStakes,
+    },
+  });
+};

--- a/src/handlers/motions/motionRewardClaimed/index.ts
+++ b/src/handlers/motions/motionRewardClaimed/index.ts
@@ -1,0 +1,1 @@
+export { default } from './motionRewardClaimed';

--- a/src/handlers/motions/motionRewardClaimed/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed/motionRewardClaimed.ts
@@ -61,8 +61,11 @@ export default async (event: ContractEvent): Promise<void> => {
       stakerRewards: updatedStakerRewards,
     };
 
-    await updateColonyUnclaimedStakes(colonyAddress, claimedMotion.id, staker);
-
     await updateMotionInDB(updatedMotionData, newMotionMessages);
+    await updateColonyUnclaimedStakes(
+      colonyAddress,
+      motionDatabaseId,
+      updatedStakerRewards,
+    );
   }
 };

--- a/src/handlers/motions/motionRewardClaimed/motionRewardClaimed.ts
+++ b/src/handlers/motions/motionRewardClaimed/motionRewardClaimed.ts
@@ -5,7 +5,8 @@ import {
   getMotionFromDB,
   updateMotionInDB,
   getMessageKey,
-} from './helpers';
+} from '../helpers';
+import { updateColonyUnclaimedStakes } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
@@ -25,9 +26,7 @@ export default async (event: ContractEvent): Promise<void> => {
   const claimedMotion = await getMotionFromDB(motionDatabaseId);
 
   if (claimedMotion) {
-    const {
-      stakerRewards,
-    } = claimedMotion;
+    const { stakerRewards } = claimedMotion;
 
     const updatedStakerRewards = stakerRewards.map((stakerReward) => {
       const { address } = stakerReward;
@@ -61,6 +60,8 @@ export default async (event: ContractEvent): Promise<void> => {
       ...claimedMotion,
       stakerRewards: updatedStakerRewards,
     };
+
+    await updateColonyUnclaimedStakes(colonyAddress, claimedMotion.id, staker);
 
     await updateMotionInDB(updatedMotionData, newMotionMessages);
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,7 +154,6 @@ export interface ColonyQuery {
     | undefined;
   motionsWithUnclaimedStakes:
     | Array<{
-        transactionHash: string;
         motionId: string;
         unclaimedRewards: StakerReward[];
       }>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,7 +152,7 @@ export interface ColonyQuery {
       }
     | null
     | undefined;
-  unclaimedStakes:
+  motionsWithUnclaimedStakes:
     | Array<{
         transactionHash: string;
         motionId: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ import {
   getLogs,
 } from '@colony/colony-js';
 import { LogDescription } from '@ethersproject/abi';
+import { StakerReward } from './motions';
 
 /*
  * Custom contract event, since we need some log values as well
@@ -149,6 +150,14 @@ export interface ColonyQuery {
           tokenAddress: string;
         } | null>;
       }
+    | null
+    | undefined;
+  unclaimedStakes:
+    | Array<{
+        transactionHash: string;
+        motionId: string;
+        unclaimedRewards: StakerReward[];
+      }>
     | null
     | undefined;
 }


### PR DESCRIPTION
This PR adds block ingestor support for the Stakes Tab in the Token Activation Popover.

Test with: https://github.com/JoinColony/colonyCDapp/pull/591 

