### PR TITLE
Round user stake percentage to 1 if percentage is zero due to rounding

### DIFF
--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -76,6 +76,12 @@ const getNewUserStakes = (
   const invertedVote = BigNumber.from(1).sub(vote);
   const stakedSide = getMotionSide(vote);
   const unstakedSide = getMotionSide(invertedVote);
+  let stakePercentage = getStakePercentage(amount, requiredStake);
+  // May be zero due to rounding. Since a user cannot stake 0%, we round up to 1.
+  if (stakePercentage.isZero()) {
+    stakePercentage = stakePercentage.add(1);
+  }
+
   return {
     address: staker,
     stakes: {
@@ -85,7 +91,7 @@ const getNewUserStakes = (
       },
 
       percentage: {
-        [stakedSide]: getStakePercentage(amount, requiredStake).toString(),
+        [stakedSide]: stakePercentage.toString(),
         [unstakedSide]: '0',
       },
     }, // TS doesn't like the computed keys, but we know they're correct

--- a/src/handlers/motions/motionStaked/helpers.ts
+++ b/src/handlers/motions/motionStaked/helpers.ts
@@ -19,22 +19,15 @@ export const getMotionStakes = (
   [totalNayStakesRaw, totalYayStakesRaw]: [BigNumber, BigNumber],
   vote: BigNumber,
 ): MotionStakes => {
-  let totalYayStakesPercentage = getStakePercentage(
+  const totalYayStakesPercentage = getStakePercentage(
     totalYayStakesRaw,
     requiredStake,
   );
 
-  let totalNayStakesPercentage = getStakePercentage(
+  const totalNayStakesPercentage = getStakePercentage(
     totalNayStakesRaw,
     requiredStake,
   );
-
-  // May be zero due to rounding. Since a user cannot stake 0%, we round up to 1.
-  if (vote.eq(MotionVote.YAY) && totalYayStakesPercentage.isZero()) {
-    totalYayStakesPercentage = totalYayStakesPercentage.add(1);
-  } else if (vote.eq(MotionVote.NAY) && totalNayStakesPercentage.isZero()) {
-    totalNayStakesPercentage = totalYayStakesPercentage.add(1);
-  }
 
   const motionStakes: MotionStakes = {
     raw: {
@@ -62,7 +55,11 @@ export const getRemainingStakes = (
 export const getStakePercentage = (
   stake: BigNumber,
   requiredStake: BigNumber,
-): BigNumber => stake.mul(100).div(requiredStake);
+): BigNumber => {
+  const stakePercentage = stake.mul(100).div(requiredStake);
+  // May be zero due to rounding. Since a user cannot stake 0%, we round up to 1.
+  return stakePercentage.isZero() ? stakePercentage.add(1) : stakePercentage;
+};
 
 /**
  * Given staking data, format and return new UserStakes object
@@ -76,11 +73,7 @@ const getNewUserStakes = (
   const invertedVote = BigNumber.from(1).sub(vote);
   const stakedSide = getMotionSide(vote);
   const unstakedSide = getMotionSide(invertedVote);
-  let stakePercentage = getStakePercentage(amount, requiredStake);
-  // May be zero due to rounding. Since a user cannot stake 0%, we round up to 1.
-  if (stakePercentage.isZero()) {
-    stakePercentage = stakePercentage.add(1);
-  }
+  const stakePercentage = getStakePercentage(amount, requiredStake);
 
   return {
     address: staker,


### PR DESCRIPTION
For a user stake, there are a few places in the staking UI where a 0% user stake is displayed and this can conflict with the motion stake percentage that always shows a minimum of 1%.

Since its not possible for a user to stake 0% and it visually makes more sense to show 1% since we don't show fractional percentages, this fix makes it so the minimum percent for a user stake is always 1%.

Contributes to colonyCDapp#648