### PR TITLE
Ensure claim shows when transferring between colonies

### DIFF
--- a/src/handlers/actions/payment.ts
+++ b/src/handlers/actions/payment.ts
@@ -1,7 +1,14 @@
 import { utils } from 'ethers';
-import { ColonyActionType } from '~graphql';
+import { mutate } from '~amplifyClient';
+import {
+  ColonyActionType,
+  CreateColonyFundsClaimDocument,
+  CreateColonyFundsClaimMutation,
+  CreateColonyFundsClaimMutationVariables,
+} from '~graphql';
+import networkClient from '~networkClient';
 
-import provider from '~provider';
+import provider, { getChainId } from '~provider';
 import { ContractEvent, ContractEventsSignatures } from '~types';
 import {
   writeActionFromEvent,
@@ -21,7 +28,12 @@ const events = [
 const hashedSignatures = events.map((signature) => utils.id(signature));
 
 export default async (paymentAddedEvent: ContractEvent): Promise<void> => {
-  const { contractAddress: colonyAddress, transactionHash } = paymentAddedEvent;
+  const {
+    contractAddress: colonyAddress,
+    transactionHash,
+    logIndex,
+    blockNumber,
+  } = paymentAddedEvent;
 
   const colonyClient = await getCachedColonyClient(colonyAddress);
 
@@ -53,8 +65,29 @@ export default async (paymentAddedEvent: ContractEvent): Promise<void> => {
   const { paymentId } = paymentAddedEvent.args;
   const { recipient: recipientAddress, domainId } =
     await colonyClient.getPayment(paymentId);
+
+  const recipientIsColony = await networkClient.isColony(recipientAddress);
+
   const { token: tokenAddress, amount } = payoutClaimedEvent.args;
   const [initiatorAddress, fundamentalChainId] = oneTxPaymentMadeEvent.args;
+
+  if (recipientIsColony) {
+    const chainId = getChainId();
+    const claimId = `${chainId}_${transactionHash}_${logIndex}`;
+
+    await mutate<
+      CreateColonyFundsClaimMutation,
+      CreateColonyFundsClaimMutationVariables
+    >(CreateColonyFundsClaimDocument, {
+      input: {
+        id: claimId,
+        colonyFundsClaimsId: recipientAddress,
+        colonyFundsClaimTokenId: tokenAddress,
+        createdAtBlock: blockNumber,
+        amount: amount.toString(),
+      },
+    });
+  }
 
   await writeActionFromEvent(paymentAddedEvent, colonyAddress, {
     type: ColonyActionType.Payment,


### PR DESCRIPTION
Currently, if you make a payment from one colony to another, the claim event will not be shown in the colony ui, meaning the user cannot claim the funds in the recipient colony. 

This PR checks when making a payment if the recipient is a colony, and if so, will add the claim to the db.

## Testing

Use branch: https://github.com/JoinColony/colonyCDapp/pull/718

In Colony A, make a payment to Colony B using Colony A native token.
In Colony B, you can now see the incoming funds claim.
If you add the token to Colony B's balances, you will see it appear after claiming.