### PR TITLE
Handle expenditure cancellation

### DIFF
--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -78,6 +78,7 @@ export const setupListenersForColony = (colonyAddress: string): void => {
     ContractEventsSignatures.ExpenditureRecipientSet,
     ContractEventsSignatures.ExpenditurePayoutSet,
     ContractEventsSignatures.ExpenditureLocked,
+    ContractEventsSignatures.ExpenditureCancelled,
   ];
 
   colonyEvents.forEach((eventSignature) =>

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -33,6 +33,7 @@ import {
   handleExpenditureRecipientSet,
   handleExpenditurePayoutSet,
   handleExpenditureLocked,
+  handleExpenditureCancelled,
 } from './handlers';
 
 dotenv.config();
@@ -232,6 +233,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExpenditureLocked: {
       await handleExpenditureLocked(event);
+      return;
+    }
+
+    case ContractEventsSignatures.ExpenditureCancelled: {
+      await handleExpenditureCancelled(event);
       return;
     }
 

--- a/src/handlers/expenditures/expenditureCancelled.ts
+++ b/src/handlers/expenditures/expenditureCancelled.ts
@@ -1,0 +1,32 @@
+import { mutate } from '~amplifyClient';
+import {
+  ExpenditureStatus,
+  UpdateExpenditureDocument,
+  UpdateExpenditureMutation,
+  UpdateExpenditureMutationVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { getExpenditureDatabaseId, toNumber, verbose } from '~utils';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { contractAddress: colonyAddress } = event;
+  const { expenditureId } = event.args;
+  const convertedExpenditureId = toNumber(expenditureId);
+
+  verbose(
+    'Expenditure with ID',
+    convertedExpenditureId,
+    'cancelled in Colony:',
+    colonyAddress,
+  );
+
+  await mutate<UpdateExpenditureMutation, UpdateExpenditureMutationVariables>(
+    UpdateExpenditureDocument,
+    {
+      input: {
+        id: getExpenditureDatabaseId(colonyAddress, convertedExpenditureId),
+        status: ExpenditureStatus.Cancelled,
+      },
+    },
+  );
+};

--- a/src/handlers/expenditures/index.ts
+++ b/src/handlers/expenditures/index.ts
@@ -2,3 +2,4 @@ export { default as handleExpenditureAdded } from './expenditureAdded';
 export { default as handleExpenditureRecipientSet } from './expenditureRecipientSet';
 export { default as handleExpenditurePayoutSet } from './expenditurePayoutSet';
 export { default as handleExpenditureLocked } from './expenditureLocked';
+export { default as handleExpenditureCancelled } from './expenditureCancelled';


### PR DESCRIPTION
This PR adds a handler for the `ExpenditureCancelled` event. 

Once you've tested this PR I recommend testing #105 since many testing steps are common.

## Testing
1. In truffle console (`npm run truffle console`), run the following commands:
```js
const { BN } = require("bn.js");
const UINT256_MAX = new BN(0).notn(256)

c = await IColony.at('<your colony address>')
// Create an expenditure in root domain using root domain's permissions
c.makeExpenditure(1, UINT256_MAX, 1)
```
2. You can use the following query to verify the expenditure has been stored in the DB (and its status is `DRAFT`):
```gql
query ListExpenditures {
  listExpenditures {
    items {
      id
      status
    }
  }
}
```
3. Cancel the expenditure with the following command:
```js
// If it's the first expenditure you created, the (native) ID will be 1, then it goes up incrementally:
c.cancelExpenditure(1)
```
4. Using the query above, verify the status has updated to `CANCELLED`.
