### PR TITLE
Handle expenditure finalization

### DIFF
--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -79,6 +79,7 @@ export const setupListenersForColony = (colonyAddress: string): void => {
     ContractEventsSignatures.ExpenditurePayoutSet,
     ContractEventsSignatures.ExpenditureLocked,
     ContractEventsSignatures.ExpenditureCancelled,
+    ContractEventsSignatures.ExpenditureFinalized,
   ];
 
   colonyEvents.forEach((eventSignature) =>

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -34,6 +34,7 @@ import {
   handleExpenditurePayoutSet,
   handleExpenditureLocked,
   handleExpenditureCancelled,
+  handleExpenditureFinalized,
 } from './handlers';
 
 dotenv.config();
@@ -238,6 +239,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExpenditureCancelled: {
       await handleExpenditureCancelled(event);
+      return;
+    }
+
+    case ContractEventsSignatures.ExpenditureFinalized: {
+      await handleExpenditureFinalized(event);
       return;
     }
 

--- a/src/handlers/expenditures/expenditureFinalized.ts
+++ b/src/handlers/expenditures/expenditureFinalized.ts
@@ -1,0 +1,32 @@
+import { mutate } from '~amplifyClient';
+import {
+  ExpenditureStatus,
+  UpdateExpenditureDocument,
+  UpdateExpenditureMutation,
+  UpdateExpenditureMutationVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { getExpenditureDatabaseId, toNumber, verbose } from '~utils';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { contractAddress: colonyAddress } = event;
+  const { expenditureId } = event.args;
+  const convertedExpenditureId = toNumber(expenditureId);
+
+  verbose(
+    'Expenditure with ID',
+    convertedExpenditureId,
+    'finalized in Colony:',
+    colonyAddress,
+  );
+
+  await mutate<UpdateExpenditureMutation, UpdateExpenditureMutationVariables>(
+    UpdateExpenditureDocument,
+    {
+      input: {
+        id: getExpenditureDatabaseId(colonyAddress, convertedExpenditureId),
+        status: ExpenditureStatus.Finalized,
+      },
+    },
+  );
+};

--- a/src/handlers/expenditures/index.ts
+++ b/src/handlers/expenditures/index.ts
@@ -3,3 +3,4 @@ export { default as handleExpenditureRecipientSet } from './expenditureRecipient
 export { default as handleExpenditurePayoutSet } from './expenditurePayoutSet';
 export { default as handleExpenditureLocked } from './expenditureLocked';
 export { default as handleExpenditureCancelled } from './expenditureCancelled';
+export { default as handleExpenditureFinalized } from './expenditureFinalized';


### PR DESCRIPTION
This PR adds a handler for the `ExpenditureFinalized` event. 

## Testing
1. In truffle console (`npm run truffle console`), run the following commands:
```js
const { BN } = require("bn.js");
const UINT256_MAX = new BN(0).notn(256)

c = await IColony.at('<your colony address>')
// Create an expenditure in root domain using root domain's permissions
c.makeExpenditure(1, UINT256_MAX, 1)
```
2. You can use the following query to verify the expenditure has been stored in the DB (and its status is `DRAFT`):
```gql
query ListExpenditures {
  listExpenditures {
    items {
      id
      status
    }
  }
}
```
3. Finalize the expenditure with the following command:
```js
// If it's the first expenditure you created, the (native) ID will be 1, then it goes up incrementally:
c.finalizeExpenditure(1)
```
4. Using the query above, verify the status has updated to `FINALIZED`.
