### PR TITLE
Handle expenditure transfer

### DIFF
--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -80,6 +80,7 @@ export const setupListenersForColony = (colonyAddress: string): void => {
     ContractEventsSignatures.ExpenditureLocked,
     ContractEventsSignatures.ExpenditureCancelled,
     ContractEventsSignatures.ExpenditureFinalized,
+    ContractEventsSignatures.ExpenditureTransferred,
   ];
 
   colonyEvents.forEach((eventSignature) =>

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -35,6 +35,7 @@ import {
   handleExpenditureLocked,
   handleExpenditureCancelled,
   handleExpenditureFinalized,
+  handleExpenditureTransferred,
 } from './handlers';
 
 dotenv.config();
@@ -244,6 +245,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExpenditureFinalized: {
       await handleExpenditureFinalized(event);
+      return;
+    }
+
+    case ContractEventsSignatures.ExpenditureTransferred: {
+      await handleExpenditureTransferred(event);
       return;
     }
 

--- a/src/handlers/expenditures/expenditureTransferred.ts
+++ b/src/handlers/expenditures/expenditureTransferred.ts
@@ -1,0 +1,33 @@
+import { mutate } from '~amplifyClient';
+import {
+  UpdateExpenditureDocument,
+  UpdateExpenditureMutation,
+  UpdateExpenditureMutationVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { getExpenditureDatabaseId, toNumber, verbose } from '~utils';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { contractAddress: colonyAddress } = event;
+  const { expenditureId, owner: newOwnerAddress } = event.args;
+  const convertedExpenditureId = toNumber(expenditureId);
+
+  verbose(
+    'Expenditure with ID',
+    convertedExpenditureId,
+    'transferred to address:',
+    newOwnerAddress,
+    'in Colony:',
+    colonyAddress,
+  );
+
+  await mutate<UpdateExpenditureMutation, UpdateExpenditureMutationVariables>(
+    UpdateExpenditureDocument,
+    {
+      input: {
+        id: getExpenditureDatabaseId(colonyAddress, convertedExpenditureId),
+        ownerAddress: newOwnerAddress,
+      },
+    },
+  );
+};

--- a/src/handlers/expenditures/index.ts
+++ b/src/handlers/expenditures/index.ts
@@ -4,3 +4,4 @@ export { default as handleExpenditurePayoutSet } from './expenditurePayoutSet';
 export { default as handleExpenditureLocked } from './expenditureLocked';
 export { default as handleExpenditureCancelled } from './expenditureCancelled';
 export { default as handleExpenditureFinalized } from './expenditureFinalized';
+export { default as handleExpenditureTransferred } from './expenditureTransferred';


### PR DESCRIPTION
This PR adds a handler for the `ExpenditureTransferred` event. 

## Testing
1. In truffle console (`npm run truffle console`), run the following commands:
```js
const { BN } = require("bn.js");
const UINT256_MAX = new BN(0).notn(256)

c = await IColony.at('<your colony address>')
// Create an expenditure in root domain using root domain's permissions
c.makeExpenditure(1, UINT256_MAX, 1)
```
2. You can use the following query to verify the expenditure has been stored in the DB with your wallet address as the `ownerAddress`.
```gql
query ListExpenditures {
  listExpenditures {
    items {
      id
      ownerAddress
    }
  }
}
```
3. Transfer the expenditure ownership with the following command:
```js
// If it's the first expenditure you created, the (native) ID will be 1, then it goes up incrementally:
c.transferExpenditure(1, '<new owner address>')
```
4. Using the query above, verify the `ownerAddress` has been updated to the new owner address.
