### PR TITLE
Handle setting expenditure claim delay

### DIFF
--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -82,6 +82,7 @@ export const setupListenersForColony = (colonyAddress: string): void => {
     ContractEventsSignatures.ExpenditureCancelled,
     ContractEventsSignatures.ExpenditureFinalized,
     ContractEventsSignatures.ExpenditureTransferred,
+    ContractEventsSignatures.ExpenditureClaimDelaySet,
   ];
 
   colonyEvents.forEach((eventSignature) =>

--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -74,6 +74,7 @@ export const setupListenersForColony = (colonyAddress: string): void => {
     ContractEventsSignatures.ColonyRoleSet,
     ContractEventsSignatures.RecoveryRoleSet,
     ContractEventsSignatures.ColonyRoleSet_OLD,
+    ContractEventsSignatures.ExpenditureGlobalClaimDelaySet,
     ContractEventsSignatures.ExpenditureAdded,
     ContractEventsSignatures.ExpenditureRecipientSet,
     ContractEventsSignatures.ExpenditurePayoutSet,

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -36,6 +36,7 @@ import {
   handleExpenditureCancelled,
   handleExpenditureFinalized,
   handleExpenditureTransferred,
+  handleExpenditureGlobalClaimDelaySet,
 } from './handlers';
 
 dotenv.config();
@@ -215,6 +216,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.RecoveryRoleSet: {
       await handleManagePermissionsAction(event);
+      return;
+    }
+
+    case ContractEventsSignatures.ExpenditureGlobalClaimDelaySet: {
+      await handleExpenditureGlobalClaimDelaySet(event);
       return;
     }
 

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -37,6 +37,7 @@ import {
   handleExpenditureFinalized,
   handleExpenditureTransferred,
   handleExpenditureGlobalClaimDelaySet,
+  handleExpenditureClaimDelaySet,
 } from './handlers';
 
 dotenv.config();
@@ -256,6 +257,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExpenditureTransferred: {
       await handleExpenditureTransferred(event);
+      return;
+    }
+
+    case ContractEventsSignatures.ExpenditureClaimDelaySet: {
+      await handleExpenditureClaimDelaySet(event);
       return;
     }
 

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -957,12 +957,14 @@ export type ExpenditurePayoutInput = {
 
 export type ExpenditureSlot = {
   __typename?: 'ExpenditureSlot';
+  claimDelay?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
   payouts?: Maybe<Array<ExpenditurePayout>>;
   recipientAddress?: Maybe<Scalars['String']>;
 };
 
 export type ExpenditureSlotInput = {
+  claimDelay?: InputMaybe<Scalars['Int']>;
   id: Scalars['Int'];
   payouts?: InputMaybe<Array<ExpenditurePayoutInput>>;
   recipientAddress?: InputMaybe<Scalars['String']>;
@@ -4731,6 +4733,7 @@ export type GetExpenditureQuery = {
       __typename?: 'ExpenditureSlot';
       id: number;
       recipientAddress?: string | null;
+      claimDelay?: number | null;
       payouts?: Array<{
         __typename?: 'ExpenditurePayout';
         tokenAddress: string;
@@ -5527,6 +5530,7 @@ export const GetExpenditureDocument = gql`
       slots {
         id
         recipientAddress
+        claimDelay
         payouts {
           tokenAddress
           amount

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -54,6 +54,7 @@ export type Colony = {
   createdAt: Scalars['AWSDateTime'];
   domains?: Maybe<ModelDomainConnection>;
   expenditures?: Maybe<ModelExpenditureConnection>;
+  expendituresGlobalClaimDelay?: Maybe<Scalars['Int']>;
   extensions?: Maybe<ModelColonyExtensionConnection>;
   fundsClaims?: Maybe<ModelColonyFundsClaimConnection>;
   id: Scalars['ID'];
@@ -551,6 +552,7 @@ export type CreateColonyInput = {
   balances?: InputMaybe<ColonyBalancesInput>;
   chainFundsClaim?: InputMaybe<ColonyChainFundsClaimInput>;
   chainMetadata: ChainMetadataInput;
+  expendituresGlobalClaimDelay?: InputMaybe<Scalars['Int']>;
   id?: InputMaybe<Scalars['ID']>;
   motionsWithUnclaimedStakes?: InputMaybe<Array<ColonyUnclaimedStakeInput>>;
   name: Scalars['String'];
@@ -1149,6 +1151,7 @@ export type ModelColonyActionTypeInput = {
 
 export type ModelColonyConditionInput = {
   and?: InputMaybe<Array<InputMaybe<ModelColonyConditionInput>>>;
+  expendituresGlobalClaimDelay?: InputMaybe<ModelIntInput>;
   name?: InputMaybe<ModelStringInput>;
   nativeTokenId?: InputMaybe<ModelIdInput>;
   not?: InputMaybe<ModelColonyConditionInput>;
@@ -1200,6 +1203,7 @@ export type ModelColonyExtensionFilterInput = {
 
 export type ModelColonyFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelColonyFilterInput>>>;
+  expendituresGlobalClaimDelay?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
   name?: InputMaybe<ModelStringInput>;
   nativeTokenId?: InputMaybe<ModelIdInput>;
@@ -1850,6 +1854,7 @@ export type ModelSubscriptionColonyExtensionFilterInput = {
 
 export type ModelSubscriptionColonyFilterInput = {
   and?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyFilterInput>>>;
+  expendituresGlobalClaimDelay?: InputMaybe<ModelSubscriptionIntInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   name?: InputMaybe<ModelSubscriptionStringInput>;
   nativeTokenId?: InputMaybe<ModelSubscriptionIdInput>;
@@ -3811,6 +3816,7 @@ export type UpdateColonyInput = {
   balances?: InputMaybe<ColonyBalancesInput>;
   chainFundsClaim?: InputMaybe<ColonyChainFundsClaimInput>;
   chainMetadata?: InputMaybe<ChainMetadataInput>;
+  expendituresGlobalClaimDelay?: InputMaybe<Scalars['Int']>;
   id: Scalars['ID'];
   motionsWithUnclaimedStakes?: InputMaybe<Array<ColonyUnclaimedStakeInput>>;
   name?: InputMaybe<Scalars['String']>;

--- a/src/graphql/queries/expenditures.graphql
+++ b/src/graphql/queries/expenditures.graphql
@@ -4,6 +4,7 @@ query GetExpenditure($id: ID!) {
     slots {
       id
       recipientAddress
+      claimDelay
       payouts {
         tokenAddress
         amount

--- a/src/handlers/expenditures/expenditureClaimDelaySet.ts
+++ b/src/handlers/expenditures/expenditureClaimDelaySet.ts
@@ -1,0 +1,59 @@
+import { mutate } from '~amplifyClient';
+import {
+  ExpenditureSlot,
+  UpdateExpenditureDocument,
+  UpdateExpenditureMutation,
+  UpdateExpenditureMutationVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { getExpenditureDatabaseId, output, toNumber, verbose } from '~utils';
+
+import { getExpenditure } from './helpers';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { contractAddress: colonyAddress } = event;
+  const { expenditureId, slot, claimDelay } = event.args;
+  const convertedExpenditureId = toNumber(expenditureId);
+  const convertedSlot = toNumber(slot);
+  const convertedClaimDelay = toNumber(claimDelay);
+
+  const databaseId = getExpenditureDatabaseId(
+    colonyAddress,
+    convertedExpenditureId,
+  );
+
+  const expenditure = await getExpenditure(databaseId);
+  if (!expenditure) {
+    output(
+      `Could not find expenditure with ID: ${convertedExpenditureId} and colony address: ${colonyAddress} in the db. This is a bug and needs investigating.`,
+    );
+    return;
+  }
+
+  const existingSlot = expenditure.slots.find(
+    (slot) => slot.id === convertedSlot,
+  );
+  const updatedSlot: ExpenditureSlot = {
+    ...existingSlot,
+    id: convertedSlot,
+    claimDelay: convertedClaimDelay,
+  };
+  const updatedSlots = [
+    ...expenditure.slots.filter((slot) => slot.id !== convertedSlot),
+    updatedSlot,
+  ];
+
+  verbose(
+    `Claim delay set for expenditure with ID ${convertedExpenditureId} in colony ${colonyAddress}`,
+  );
+
+  await mutate<UpdateExpenditureMutation, UpdateExpenditureMutationVariables>(
+    UpdateExpenditureDocument,
+    {
+      input: {
+        id: databaseId,
+        slots: updatedSlots,
+      },
+    },
+  );
+};

--- a/src/handlers/expenditures/expenditureGlobalClaimDelaySet.ts
+++ b/src/handlers/expenditures/expenditureGlobalClaimDelaySet.ts
@@ -1,0 +1,24 @@
+import { mutate } from '~amplifyClient';
+import {
+  UpdateColonyDocument,
+  UpdateColonyMutation,
+  UpdateColonyMutationVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { toNumber } from '~utils';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { contractAddress: colonyAddress } = event;
+  const { globalClaimDelay } = event.args;
+  const convertedGlobalClaimDelay = toNumber(globalClaimDelay);
+
+  await mutate<UpdateColonyMutation, UpdateColonyMutationVariables>(
+    UpdateColonyDocument,
+    {
+      input: {
+        id: colonyAddress,
+        expendituresGlobalClaimDelay: convertedGlobalClaimDelay,
+      },
+    },
+  );
+};

--- a/src/handlers/expenditures/index.ts
+++ b/src/handlers/expenditures/index.ts
@@ -6,3 +6,4 @@ export { default as handleExpenditureCancelled } from './expenditureCancelled';
 export { default as handleExpenditureFinalized } from './expenditureFinalized';
 export { default as handleExpenditureTransferred } from './expenditureTransferred';
 export { default as handleExpenditureGlobalClaimDelaySet } from './expenditureGlobalClaimDelaySet';
+export { default as handleExpenditureClaimDelaySet } from './expenditureClaimDelaySet';

--- a/src/handlers/expenditures/index.ts
+++ b/src/handlers/expenditures/index.ts
@@ -5,3 +5,4 @@ export { default as handleExpenditureLocked } from './expenditureLocked';
 export { default as handleExpenditureCancelled } from './expenditureCancelled';
 export { default as handleExpenditureFinalized } from './expenditureFinalized';
 export { default as handleExpenditureTransferred } from './expenditureTransferred';
+export { default as handleExpenditureGlobalClaimDelaySet } from './expenditureGlobalClaimDelaySet';

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -66,6 +66,7 @@ export enum ContractEventsSignatures {
 
   // Expenditures
   ExpenditureGlobalClaimDelaySet = 'ExpenditureGlobalClaimDelaySet(address,uint256)',
+  ExpenditureClaimDelaySet = 'ExpenditureClaimDelaySet(address,uint256,uint256,uint256)',
   ExpenditureAdded = 'ExpenditureAdded(address,uint256)',
   ExpenditureTransferred = 'ExpenditureTransferred(address,uint256,address)',
   ExpenditureCancelled = 'ExpenditureCancelled(address,uint256)',


### PR DESCRIPTION
This PR adds handlers for `ExpenditureGlobalClaimDelaySet` and `ExpenditureClaimDelaySet` events.

## Testing
### Common step
1. In truffle console (`npm run truffle console`), run the following commands:
```js
const { BN } = require("bn.js");
const UINT256_MAX = new BN(0).notn(256)

c = await IColony.at('<your colony address>')
```

### ExpenditureGlobalClaimDelaySet
1. Use the following query to verify there's no global claim delay set:
```gql
query GetColony {
  getColony(id: "<your colony address>") {
    expendituresGlobalClaimDelay
  }
}
```
2. In truffle console, set the global claim delay:
```js
c.setDefaultGlobalClaimDelay(100) // 100 seconds
```
3. Verify the claim delay has been correctly stored on the colony object.

### ExpenditureClaimDelaySet
1. Run the following commands in truffle:
```js
// Create an expenditure in root domain using root domain's permissions
c.makeExpenditure(1, UINT256_MAX, 1)
// Set recipient address for expenditure slot 1
c.setExpenditureRecipients(1, 1, '<recipient address>')
// Set the payout amount for slot 1
c.setExpenditurePayout(1, 1, '<token address>', 500)
// Set the claim delay for slot 1 
c.setExpenditureClaimDelay(1, 1, 100) // 100 seconds
```
2. Using the following query, verify the data has been correctly stored in the DB:
```gql
query ListExpenditures {
  listExpenditures {
    items {
      slots { 
        id
        recipientAddress
        claimDelay
        payouts {
          tokenAddress
          amount
        }
      } 
    }
  }
}
```