### PR TITLE
Handle setting expenditure payout modifier

### DIFF
--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -83,6 +83,7 @@ export const setupListenersForColony = (colonyAddress: string): void => {
     ContractEventsSignatures.ExpenditureFinalized,
     ContractEventsSignatures.ExpenditureTransferred,
     ContractEventsSignatures.ExpenditureClaimDelaySet,
+    ContractEventsSignatures.ExpenditurePayoutModifierSet,
   ];
 
   colonyEvents.forEach((eventSignature) =>

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -38,6 +38,7 @@ import {
   handleExpenditureTransferred,
   handleExpenditureGlobalClaimDelaySet,
   handleExpenditureClaimDelaySet,
+  handleExpenditurePayoutModifierSet,
 } from './handlers';
 
 dotenv.config();
@@ -262,6 +263,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.ExpenditureClaimDelaySet: {
       await handleExpenditureClaimDelaySet(event);
+      return;
+    }
+
+    case ContractEventsSignatures.ExpenditurePayoutModifierSet: {
+      await handleExpenditurePayoutModifierSet(event);
       return;
     }
 

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -959,6 +959,7 @@ export type ExpenditureSlot = {
   __typename?: 'ExpenditureSlot';
   claimDelay?: Maybe<Scalars['Int']>;
   id: Scalars['Int'];
+  payoutModifier?: Maybe<Scalars['Int']>;
   payouts?: Maybe<Array<ExpenditurePayout>>;
   recipientAddress?: Maybe<Scalars['String']>;
 };
@@ -966,6 +967,7 @@ export type ExpenditureSlot = {
 export type ExpenditureSlotInput = {
   claimDelay?: InputMaybe<Scalars['Int']>;
   id: Scalars['Int'];
+  payoutModifier?: InputMaybe<Scalars['Int']>;
   payouts?: InputMaybe<Array<ExpenditurePayoutInput>>;
   recipientAddress?: InputMaybe<Scalars['String']>;
 };
@@ -4734,6 +4736,7 @@ export type GetExpenditureQuery = {
       id: number;
       recipientAddress?: string | null;
       claimDelay?: number | null;
+      payoutModifier?: number | null;
       payouts?: Array<{
         __typename?: 'ExpenditurePayout';
         tokenAddress: string;
@@ -5531,6 +5534,7 @@ export const GetExpenditureDocument = gql`
         id
         recipientAddress
         claimDelay
+        payoutModifier
         payouts {
           tokenAddress
           amount

--- a/src/graphql/queries/expenditures.graphql
+++ b/src/graphql/queries/expenditures.graphql
@@ -5,6 +5,7 @@ query GetExpenditure($id: ID!) {
       id
       recipientAddress
       claimDelay
+      payoutModifier
       payouts {
         tokenAddress
         amount

--- a/src/handlers/expenditures/expenditurePayoutModifierSet.ts
+++ b/src/handlers/expenditures/expenditurePayoutModifierSet.ts
@@ -1,0 +1,56 @@
+import { ContractEvent } from '~types';
+import { getExpenditureDatabaseId, output, toNumber, verbose } from '~utils';
+import {
+  ExpenditureSlot,
+  UpdateExpenditureDocument,
+  UpdateExpenditureMutation,
+  UpdateExpenditureMutationVariables,
+} from '~graphql';
+import { mutate } from '~amplifyClient';
+
+import { getExpenditure } from './helpers';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { contractAddress: colonyAddress } = event;
+  const { expenditureId, slot, payoutModifier } = event.args;
+  const convertedExpenditureId = toNumber(expenditureId);
+  const convertedSlot = toNumber(slot);
+  const convertedPayoutModifier = toNumber(payoutModifier);
+
+  const databaseId = getExpenditureDatabaseId(colonyAddress, expenditureId);
+
+  const expenditure = await getExpenditure(databaseId);
+  if (!expenditure) {
+    output(
+      `Could not find expenditure with ID: ${convertedExpenditureId} and colony address: ${colonyAddress} in the db. This is a bug and needs investigating.`,
+    );
+    return;
+  }
+
+  const existingSlot = expenditure.slots.find(
+    (slot) => slot.id === convertedSlot,
+  );
+  const updatedSlot: ExpenditureSlot = {
+    ...existingSlot,
+    id: convertedSlot,
+    payoutModifier: convertedPayoutModifier,
+  };
+  const updatedSlots = [
+    ...expenditure.slots.filter((slot) => slot.id !== convertedSlot),
+    updatedSlot,
+  ];
+
+  verbose(
+    `Payout modifier set for expenditure with ID ${convertedExpenditureId} in colony ${colonyAddress}`,
+  );
+
+  await mutate<UpdateExpenditureMutation, UpdateExpenditureMutationVariables>(
+    UpdateExpenditureDocument,
+    {
+      input: {
+        id: databaseId,
+        slots: updatedSlots,
+      },
+    },
+  );
+};

--- a/src/handlers/expenditures/index.ts
+++ b/src/handlers/expenditures/index.ts
@@ -7,3 +7,4 @@ export { default as handleExpenditureFinalized } from './expenditureFinalized';
 export { default as handleExpenditureTransferred } from './expenditureTransferred';
 export { default as handleExpenditureGlobalClaimDelaySet } from './expenditureGlobalClaimDelaySet';
 export { default as handleExpenditureClaimDelaySet } from './expenditureClaimDelaySet';
+export { default as handleExpenditurePayoutModifierSet } from './expenditurePayoutModifierSet';

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -74,6 +74,7 @@ export enum ContractEventsSignatures {
   ExpenditureFinalized = 'ExpenditureFinalized(address,uint256)',
   ExpenditureRecipientSet = 'ExpenditureRecipientSet(address,uint256,uint256,address)',
   ExpenditurePayoutSet = 'ExpenditurePayoutSet(address,uint256,uint256,address,uint256)',
+  ExpenditurePayoutModifierSet = 'ExpenditurePayoutModifierSet(address,uint256,uint256,int256)',
 }
 
 /*


### PR DESCRIPTION
This PR adds a handler for ExpenditurePayoutModifierSet event.

## Testing
1. In truffle console (`npm run truffle console`), run the following commands:
```js
const { BN } = require("bn.js");
const UINT256_MAX = new BN(0).notn(256)

c = await IColony.at('<your colony address>')
// Create an expenditure in root domain using root domain's permissions
c.makeExpenditure(1, UINT256_MAX, 1)

// Set payout modifier of 100 for slot 1
c.setExpenditurePayoutModifiers(1, [1], [100]) // arguments: expenditure id, array of slot numbers, array of modifiers
```

2. Use the following query to verify the modifier has been stored:
```gql
query ListExpenditures {
  listExpenditures {
    items {
      slots { 
        id
        payoutModifier
      } 
    }
  }
}
```

