### PR TITLE
Fix arbitrary reputation update handler

### DIFF
--- a/src/graphql/fragments/colony.graphql
+++ b/src/graphql/fragments/colony.graphql
@@ -17,4 +17,12 @@ fragment Colony on Colony {
       isClaimed
     }
   }
+  # Idea is to get all domains in one query, but we'll take the nextToken just in case
+  domains(limit: 1000, nextToken: $nextToken) {
+    items {
+      id
+      nativeSkillId
+    }
+    nextToken
+  }
 }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -5321,6 +5321,15 @@ export type ColonyFragment = {
       rewards: { __typename?: 'MotionStakeValues'; yay: string; nay: string };
     }>;
   }> | null;
+  domains?: {
+    __typename?: 'ModelDomainConnection';
+    nextToken?: string | null;
+    items: Array<{
+      __typename?: 'Domain';
+      id: string;
+      nativeSkillId: number;
+    } | null>;
+  } | null;
 };
 
 export type ExtensionFragment = {
@@ -5814,6 +5823,7 @@ export type GetColonyMetadataQuery = {
 
 export type GetColonyQueryVariables = Exact<{
   id: Scalars['ID'];
+  nextToken?: InputMaybe<Scalars['String']>;
 }>;
 
 export type GetColonyQuery = {
@@ -5839,6 +5849,15 @@ export type GetColonyQuery = {
         rewards: { __typename?: 'MotionStakeValues'; yay: string; nay: string };
       }>;
     }> | null;
+    domains?: {
+      __typename?: 'ModelDomainConnection';
+      nextToken?: string | null;
+      items: Array<{
+        __typename?: 'Domain';
+        id: string;
+        nativeSkillId: number;
+      } | null>;
+    } | null;
   } | null;
 };
 
@@ -6271,6 +6290,13 @@ export const Colony = gql`
         isClaimed
       }
     }
+    domains(limit: 1000, nextToken: $nextToken) {
+      items {
+        id
+        nativeSkillId
+      }
+      nextToken
+    }
   }
 `;
 export const Extension = gql`
@@ -6694,7 +6720,7 @@ export const GetColonyMetadataDocument = gql`
   }
 `;
 export const GetColonyDocument = gql`
-  query GetColony($id: ID!) {
+  query GetColony($id: ID!, $nextToken: String) {
     getColony(id: $id) {
       ...Colony
     }

--- a/src/graphql/queries/colony.graphql
+++ b/src/graphql/queries/colony.graphql
@@ -21,7 +21,7 @@ query GetColonyMetadata($id: ID!) {
   }
 }
 
-query GetColony($id: ID!) {
+query GetColony($id: ID!, $nextToken: String) {
   getColony(id: $id) {
     ...Colony
   }

--- a/src/handlers/actions/emitDomainReputation.ts
+++ b/src/handlers/actions/emitDomainReputation.ts
@@ -49,7 +49,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
   if (!domain) {
     verbose(
-      'Not acting upon the ArbitraryReputationUpdate event as a domain with the skillId was not found',
+      `Not acting upon the ArbitraryReputationUpdate event as a domain with the skillId ${skillId} was not found`,
     );
     return;
   }

--- a/src/handlers/actions/emitDomainReputation.ts
+++ b/src/handlers/actions/emitDomainReputation.ts
@@ -1,30 +1,14 @@
 import { BigNumber } from 'ethers';
-import { AnyColonyClient, getEvents } from '@colony/colony-js';
-import { LogDescription } from 'ethers/lib/utils';
 
 import { ContractEvent } from '~types';
+import { writeActionFromEvent, verbose, notNull } from '~utils';
 import {
-  writeActionFromEvent,
-  getDomainDatabaseId,
-  verbose,
-  getCachedColonyClient,
-} from '~utils';
-import { ColonyActionType } from '~graphql';
-
-const getChangeDomainId = async (
-  domainAddedEvents: LogDescription[],
-  colonyClient: AnyColonyClient,
-  skillId: number,
-): Promise<number | null> => {
-  for (const event of domainAddedEvents) {
-    const domainId = event.args.domainId.toString();
-    const { skillId: domainSkillId } = await colonyClient.getDomain(domainId);
-    if (domainSkillId.eq(skillId)) {
-      return domainId;
-    }
-  }
-  return null;
-};
+  ColonyActionType,
+  GetColonyDocument,
+  GetColonyQuery,
+  GetColonyQueryVariables,
+} from '~graphql';
+import { query } from '~amplifyClient';
 
 export default async (event: ContractEvent): Promise<void> => {
   const { contractAddress: colonyAddress } = event;
@@ -41,23 +25,31 @@ export default async (event: ContractEvent): Promise<void> => {
     ? ColonyActionType.EmitDomainReputationReward
     : ColonyActionType.EmitDomainReputationPenalty;
 
-  const colonyClient = await getCachedColonyClient(colonyAddress);
+  let domain;
+  let nextToken: string | undefined;
+  /*
+   * Search for domain with skillId from Colony's domains. We paginate the query
+   * just in case there are more domains than the query limit. We can stop searching
+   * if we find a domain.
+   */
+  do {
+    const { data } =
+      (await query<GetColonyQuery, GetColonyQueryVariables>(GetColonyDocument, {
+        id: colonyAddress,
+        nextToken,
+      })) ?? {};
+    domain = data?.getColony?.domains?.items
+      .filter(notNull)
+      .find(
+        ({ nativeSkillId }) => nativeSkillId.toString() === skillId.toString(),
+      );
 
-  if (!colonyClient) {
-    return;
-  }
+    nextToken = data?.getColony?.domains?.nextToken ?? '';
+  } while (!domain && nextToken);
 
-  const domainAddedFilter = colonyClient.filters.DomainAdded(null, null);
-  const domainAddedEvents = await getEvents(colonyClient, domainAddedFilter);
-  const changeDomainId = await getChangeDomainId(
-    domainAddedEvents,
-    colonyClient,
-    skillId,
-  );
-
-  if (!changeDomainId) {
+  if (!domain) {
     verbose(
-      'Not acting upon the ArbitraryReputationUpdate event as a domain matching the skillId was not found',
+      'Not acting upon the ArbitraryReputationUpdate event as a domain with the skillId was not found',
     );
     return;
   }
@@ -67,6 +59,6 @@ export default async (event: ContractEvent): Promise<void> => {
     initiatorAddress,
     recipientAddress: userAddress,
     amount: amount.toString(),
-    fromDomainId: getDomainDatabaseId(colonyAddress, changeDomainId),
+    fromDomainId: domain.id,
   });
 };


### PR DESCRIPTION
This PR fixes a bug that causes the block ingestor to crash. 

In the arbitrary reputation update handler, we were using event logs to find a domain instead of the db. Lots of logs lead to an rpc timeout, leading to the block ingestor crashing.