### PR TITLE
Ensure block timestamp is saved as motion createdAt date

### DIFF
--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -211,12 +211,14 @@ const createMotionMessage = async (
 
 const createColonyAction = async (
   actionData: CreateColonyActionInput,
+  blockTimestamp: number,
 ): Promise<void> => {
   await mutate<CreateColonyActionMutation, CreateColonyActionMutationVariables>(
     CreateColonyActionDocument,
     {
       input: {
         ...actionData,
+        createdAt: new Date(blockTimestamp * 1000).toISOString(),
       },
     },
   );
@@ -229,6 +231,7 @@ export const createMotionInDB = async (
     logIndex,
     colonyAddress,
     args: { motionId, creator: creatorAddress, domainId },
+    timestamp,
   }: ContractEvent,
   {
     gasEstimate,
@@ -286,6 +289,6 @@ export const createMotionInDB = async (
   await Promise.all([
     createColonyMotion({ ...motionData, gasEstimate, expenditureId }),
     createMotionMessage(initialMotionMessage),
-    createColonyAction(actionData),
+    createColonyAction(actionData, timestamp),
   ]);
 };


### PR DESCRIPTION
This PR fixes an issue where the motion's `createdAt` date is set to the system current time rather than the block timestamp.