### PR TITLE
Throw error when failed to get a block

### DIFF
--- a/src/blockListener.ts
+++ b/src/blockListener.ts
@@ -19,8 +19,10 @@ export const startBlockListener = (): void => {
       output(`Block ${blockNumber} added to the queue`);
 
       processNextBlock();
-    } catch {
-      output(`Observed block ${blockNumber} but failed to get its data`);
+    } catch (error) {
+      throw new Error(
+        `Observed block ${blockNumber} but failed to get its data: ${error}`,
+      );
     }
   });
 


### PR DESCRIPTION
If error is not thrown, block ingestor hangs and needs to be manually restarted