### PR TITLE
Add motion timestamps to motion state history

### DIFF
--- a/src/eventListeners/extension/votingReputation.ts
+++ b/src/eventListeners/extension/votingReputation.ts
@@ -48,6 +48,7 @@ export const setupMotionsListeners = (
     ContractEventsSignatures.MotionRewardClaimed,
     ContractEventsSignatures.MotionVoteSubmitted,
     ContractEventsSignatures.MotionVoteRevealed,
+    ContractEventsSignatures.MotionEventSet,
   ];
 
   motionEvents.forEach((eventSignature) =>

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -52,6 +52,7 @@ import {
   handlePaymentTokenUpdated,
   handleSetTokenAuthority,
   handleColonyMetadataDelta,
+  handleMotionEventSet,
 } from './handlers';
 
 dotenv.config();
@@ -171,6 +172,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.MotionVoteRevealed: {
       await handleMotionVoteRevealed(event);
+      return;
+    }
+
+    case ContractEventsSignatures.MotionEventSet: {
+      await handleMotionEventSet(event);
       return;
     }
 

--- a/src/graphql/fragments/motions.graphql
+++ b/src/graphql/fragments/motions.graphql
@@ -40,6 +40,7 @@ fragment ColonyMotion on ColonyMotion {
     hasFailed
     hasFailedNotFinalizable
     inRevealPhase
+    bothSidesFullyStakedAt
   }
   isDecision
   transactionHash

--- a/src/graphql/fragments/motions.graphql
+++ b/src/graphql/fragments/motions.graphql
@@ -42,6 +42,8 @@ fragment ColonyMotion on ColonyMotion {
     inRevealPhase
     yaySideFullyStakedAt
     naySideFullyStakedAt
+    allVotesRevealedAt
+    finalizedAt
   }
   isDecision
   transactionHash

--- a/src/graphql/fragments/motions.graphql
+++ b/src/graphql/fragments/motions.graphql
@@ -40,7 +40,8 @@ fragment ColonyMotion on ColonyMotion {
     hasFailed
     hasFailedNotFinalizable
     inRevealPhase
-    bothSidesFullyStakedAt
+    yaySideFullyStakedAt
+    naySideFullyStakedAt
   }
   isDecision
   transactionHash

--- a/src/graphql/fragments/motions.graphql
+++ b/src/graphql/fragments/motions.graphql
@@ -44,6 +44,7 @@ fragment ColonyMotion on ColonyMotion {
     naySideFullyStakedAt
     allVotesSubmittedAt
     allVotesRevealedAt
+    endedAt
     finalizedAt
   }
   isDecision

--- a/src/graphql/fragments/motions.graphql
+++ b/src/graphql/fragments/motions.graphql
@@ -42,6 +42,7 @@ fragment ColonyMotion on ColonyMotion {
     inRevealPhase
     yaySideFullyStakedAt
     naySideFullyStakedAt
+    allVotesSubmittedAt
     allVotesRevealedAt
     finalizedAt
   }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8266,6 +8266,8 @@ export type ColonyMotionFragment = {
     inRevealPhase: boolean;
     yaySideFullyStakedAt?: string | null;
     naySideFullyStakedAt?: string | null;
+    allVotesRevealedAt?: string | null;
+    finalizedAt?: string | null;
   };
 };
 
@@ -9316,6 +9318,8 @@ export type GetColonyMotionQuery = {
       inRevealPhase: boolean;
       yaySideFullyStakedAt?: string | null;
       naySideFullyStakedAt?: string | null;
+      allVotesRevealedAt?: string | null;
+      finalizedAt?: string | null;
     };
   } | null;
 };
@@ -9595,6 +9599,8 @@ export const ColonyMotion = gql`
       inRevealPhase
       yaySideFullyStakedAt
       naySideFullyStakedAt
+      allVotesRevealedAt
+      finalizedAt
     }
     isDecision
     transactionHash

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8235,6 +8235,7 @@ export type ColonyMotionFragment = {
     hasFailed: boolean;
     hasFailedNotFinalizable: boolean;
     inRevealPhase: boolean;
+    bothSidesFullyStakedAt?: string | null;
   };
 };
 
@@ -9283,6 +9284,7 @@ export type GetColonyMotionQuery = {
       hasFailed: boolean;
       hasFailedNotFinalizable: boolean;
       inRevealPhase: boolean;
+      bothSidesFullyStakedAt?: string | null;
     };
   } | null;
 };
@@ -9560,6 +9562,7 @@ export const ColonyMotion = gql`
       hasFailed
       hasFailedNotFinalizable
       inRevealPhase
+      bothSidesFullyStakedAt
     }
     isDecision
     transactionHash

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -4277,9 +4277,10 @@ export type MotionStakesInput = {
 /** Quick access flages to check the current state of a motion in its lifecycle */
 export type MotionStateHistory = {
   __typename?: 'MotionStateHistory';
-  allVotesRevealedAt: Scalars['AWSDateTime'];
-  allVotesSubmittedAt: Scalars['AWSDateTime'];
-  finalizedAt: Scalars['AWSDateTime'];
+  /** Whether the motion is a Simple Decision */
+  allVotesRevealedAt?: Maybe<Scalars['AWSDateTime']>;
+  /** Whether the motion is a Simple Decision */
+  finalizedAt?: Maybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -4290,15 +4291,18 @@ export type MotionStateHistory = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
-  naySideFullyStakedAt: Scalars['AWSDateTime'];
-  yaySideFullyStakedAt: Scalars['AWSDateTime'];
+  /** Whether the motion is a Simple Decision */
+  naySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
+  /** Whether the motion is a Simple Decision */
+  yaySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
 };
 
 /** Input used to change the current state of a motion */
 export type MotionStateHistoryInput = {
-  allVotesRevealedAt: Scalars['AWSDateTime'];
-  allVotesSubmittedAt: Scalars['AWSDateTime'];
-  finalizedAt: Scalars['AWSDateTime'];
+  /** Whether the motion is a Simple Decision */
+  allVotesRevealedAt?: InputMaybe<Scalars['AWSDateTime']>;
+  /** Whether the motion is a Simple Decision */
+  finalizedAt?: InputMaybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -4309,8 +4313,10 @@ export type MotionStateHistoryInput = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
-  naySideFullyStakedAt: Scalars['AWSDateTime'];
-  yaySideFullyStakedAt: Scalars['AWSDateTime'];
+  /** Whether the motion is a Simple Decision */
+  naySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
+  /** Whether the motion is a Simple Decision */
+  yaySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
 /** Root mutation type */
@@ -8258,8 +8264,8 @@ export type ColonyMotionFragment = {
     hasFailed: boolean;
     hasFailedNotFinalizable: boolean;
     inRevealPhase: boolean;
-    yaySideFullyStakedAt: string;
-    naySideFullyStakedAt: string;
+    yaySideFullyStakedAt?: string | null;
+    naySideFullyStakedAt?: string | null;
   };
 };
 
@@ -9308,8 +9314,8 @@ export type GetColonyMotionQuery = {
       hasFailed: boolean;
       hasFailedNotFinalizable: boolean;
       inRevealPhase: boolean;
-      yaySideFullyStakedAt: string;
-      naySideFullyStakedAt: string;
+      yaySideFullyStakedAt?: string | null;
+      naySideFullyStakedAt?: string | null;
     };
   } | null;
 };

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -4277,14 +4277,13 @@ export type MotionStakesInput = {
 /** Quick access flages to check the current state of a motion in its lifecycle */
 export type MotionStateHistory = {
   __typename?: 'MotionStateHistory';
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when all votes were revealed */
   allVotesRevealedAt?: Maybe<Scalars['AWSDateTime']>;
-  /**
-   * "
-   * Whether the motion is a Simple Decision
-   */
+  /** The timestamp when all votes were submitted */
   allVotesSubmittedAt?: Maybe<Scalars['AWSDateTime']>;
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when the motion ended (Passed or failed) */
+  endedAt?: Maybe<Scalars['AWSDateTime']>;
+  /** The timestamp when the motion was finalized */
   finalizedAt?: Maybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
@@ -4296,22 +4295,21 @@ export type MotionStateHistory = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when the NAY side was fully staked */
   naySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when the YAY side was fully staked */
   yaySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
 };
 
 /** Input used to change the current state of a motion */
 export type MotionStateHistoryInput = {
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when all votes were revealed */
   allVotesRevealedAt?: InputMaybe<Scalars['AWSDateTime']>;
-  /**
-   * "
-   * Whether the motion is a Simple Decision
-   */
+  /** The timestamp when all votes were submitted */
   allVotesSubmittedAt?: InputMaybe<Scalars['AWSDateTime']>;
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when the motion ended (Passed or failed) */
+  endedAt?: InputMaybe<Scalars['AWSDateTime']>;
+  /** The timestamp when the motion was finalized */
   finalizedAt?: InputMaybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
@@ -4323,9 +4321,9 @@ export type MotionStateHistoryInput = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when the NAY side was fully staked */
   naySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
-  /** Whether the motion is a Simple Decision */
+  /** The timestamp when the YAY side was fully staked */
   yaySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
@@ -8278,6 +8276,7 @@ export type ColonyMotionFragment = {
     naySideFullyStakedAt?: string | null;
     allVotesSubmittedAt?: string | null;
     allVotesRevealedAt?: string | null;
+    endedAt?: string | null;
     finalizedAt?: string | null;
   };
 };
@@ -9331,6 +9330,7 @@ export type GetColonyMotionQuery = {
       naySideFullyStakedAt?: string | null;
       allVotesSubmittedAt?: string | null;
       allVotesRevealedAt?: string | null;
+      endedAt?: string | null;
       finalizedAt?: string | null;
     };
   } | null;
@@ -9613,6 +9613,7 @@ export const ColonyMotion = gql`
       naySideFullyStakedAt
       allVotesSubmittedAt
       allVotesRevealedAt
+      endedAt
       finalizedAt
     }
     isDecision

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -218,10 +218,7 @@ export type ColonyTokensArgs = {
 /** Represents an action performed within a Colony */
 export type ColonyAction = {
   __typename?: 'ColonyAction';
-  /**
-   * The amount involved in the action, if applicable
-   * In any case where network fee is involved, this amount excludes it
-   */
+  /** The amount involved in the action, if applicable */
   amount?: Maybe<Scalars['String']>;
   /** The annotation associated with the action, if there is one */
   annotation?: Maybe<Annotation>;
@@ -270,8 +267,6 @@ export type ColonyAction = {
   motionDomainId?: Maybe<Scalars['Int']>;
   /** The internal database id of the motion */
   motionId?: Maybe<Scalars['ID']>;
-  /** The network fee amount, if applicable */
-  networkFee?: Maybe<Scalars['String']>;
   /** The resulting new Colony version, if applicable */
   newColonyVersion?: Maybe<Scalars['Int']>;
   /** The native id of the payment */
@@ -1081,7 +1076,6 @@ export type CreateColonyActionInput = {
   members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
-  networkFee?: InputMaybe<Scalars['String']>;
   newColonyVersion?: InputMaybe<Scalars['Int']>;
   paymentId?: InputMaybe<Scalars['Int']>;
   payments?: InputMaybe<Array<PaymentInput>>;
@@ -2231,7 +2225,6 @@ export type ModelColonyActionConditionInput = {
   members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
-  networkFee?: InputMaybe<ModelStringInput>;
   newColonyVersion?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelColonyActionConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionConditionInput>>>;
@@ -2269,7 +2262,6 @@ export type ModelColonyActionFilterInput = {
   members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
-  networkFee?: InputMaybe<ModelStringInput>;
   newColonyVersion?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelColonyActionFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionFilterInput>>>;
@@ -3425,7 +3417,6 @@ export type ModelSubscriptionColonyActionFilterInput = {
   members?: InputMaybe<ModelSubscriptionIdInput>;
   motionDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   motionId?: InputMaybe<ModelSubscriptionIdInput>;
-  networkFee?: InputMaybe<ModelSubscriptionStringInput>;
   newColonyVersion?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyActionFilterInput>>>;
   paymentId?: InputMaybe<ModelSubscriptionIntInput>;
@@ -4277,6 +4268,8 @@ export type MotionStakesInput = {
 /** Quick access flages to check the current state of a motion in its lifecycle */
 export type MotionStateHistory = {
   __typename?: 'MotionStateHistory';
+  /** Timestamp at which the motion was fully staked on both sides */
+  bothSidesFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -4291,6 +4284,8 @@ export type MotionStateHistory = {
 
 /** Input used to change the current state of a motion */
 export type MotionStateHistoryInput = {
+  /** Timestamp at which the motion was fully staked on both sides */
+  bothSidesFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -5249,17 +5244,13 @@ export enum Network {
 
 export type Payment = {
   __typename?: 'Payment';
-  /** Payment amount, excluding network fee */
   amount: Scalars['String'];
-  /** Network fee amount */
-  networkFee?: Maybe<Scalars['String']>;
   recipientAddress: Scalars['String'];
   tokenAddress: Scalars['String'];
 };
 
 export type PaymentInput = {
   amount: Scalars['String'];
-  networkFee?: InputMaybe<Scalars['String']>;
   recipientAddress: Scalars['String'];
   tokenAddress: Scalars['String'];
 };
@@ -6422,7 +6413,6 @@ export enum SearchableColonyActionAggregateField {
   Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
-  NetworkFee = 'networkFee',
   NewColonyVersion = 'newColonyVersion',
   PaymentId = 'paymentId',
   PendingColonyMetadataId = 'pendingColonyMetadataId',
@@ -6467,7 +6457,6 @@ export type SearchableColonyActionFilterInput = {
   members?: InputMaybe<SearchableIdFilterInput>;
   motionDomainId?: InputMaybe<SearchableIntFilterInput>;
   motionId?: InputMaybe<SearchableIdFilterInput>;
-  networkFee?: InputMaybe<SearchableStringFilterInput>;
   newColonyVersion?: InputMaybe<SearchableIntFilterInput>;
   not?: InputMaybe<SearchableColonyActionFilterInput>;
   or?: InputMaybe<Array<InputMaybe<SearchableColonyActionFilterInput>>>;
@@ -6504,7 +6493,6 @@ export enum SearchableColonyActionSortableFields {
   Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
-  NetworkFee = 'networkFee',
   NewColonyVersion = 'newColonyVersion',
   PaymentId = 'paymentId',
   PendingColonyMetadataId = 'pendingColonyMetadataId',
@@ -7484,7 +7472,6 @@ export type UpdateColonyActionInput = {
   members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
-  networkFee?: InputMaybe<Scalars['String']>;
   newColonyVersion?: InputMaybe<Scalars['Int']>;
   paymentId?: InputMaybe<Scalars['Int']>;
   payments?: InputMaybe<Array<PaymentInput>>;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -4279,6 +4279,11 @@ export type MotionStateHistory = {
   __typename?: 'MotionStateHistory';
   /** Whether the motion is a Simple Decision */
   allVotesRevealedAt?: Maybe<Scalars['AWSDateTime']>;
+  /**
+   * "
+   * Whether the motion is a Simple Decision
+   */
+  allVotesSubmittedAt?: Maybe<Scalars['AWSDateTime']>;
   /** Whether the motion is a Simple Decision */
   finalizedAt?: Maybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
@@ -4301,6 +4306,11 @@ export type MotionStateHistory = {
 export type MotionStateHistoryInput = {
   /** Whether the motion is a Simple Decision */
   allVotesRevealedAt?: InputMaybe<Scalars['AWSDateTime']>;
+  /**
+   * "
+   * Whether the motion is a Simple Decision
+   */
+  allVotesSubmittedAt?: InputMaybe<Scalars['AWSDateTime']>;
   /** Whether the motion is a Simple Decision */
   finalizedAt?: InputMaybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
@@ -8266,6 +8276,7 @@ export type ColonyMotionFragment = {
     inRevealPhase: boolean;
     yaySideFullyStakedAt?: string | null;
     naySideFullyStakedAt?: string | null;
+    allVotesSubmittedAt?: string | null;
     allVotesRevealedAt?: string | null;
     finalizedAt?: string | null;
   };
@@ -9318,6 +9329,7 @@ export type GetColonyMotionQuery = {
       inRevealPhase: boolean;
       yaySideFullyStakedAt?: string | null;
       naySideFullyStakedAt?: string | null;
+      allVotesSubmittedAt?: string | null;
       allVotesRevealedAt?: string | null;
       finalizedAt?: string | null;
     };
@@ -9599,6 +9611,7 @@ export const ColonyMotion = gql`
       inRevealPhase
       yaySideFullyStakedAt
       naySideFullyStakedAt
+      allVotesSubmittedAt
       allVotesRevealedAt
       finalizedAt
     }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -4277,6 +4277,9 @@ export type MotionStakesInput = {
 /** Quick access flages to check the current state of a motion in its lifecycle */
 export type MotionStateHistory = {
   __typename?: 'MotionStateHistory';
+  allVotesRevealedAt: Scalars['AWSDateTime'];
+  allVotesSubmittedAt: Scalars['AWSDateTime'];
+  finalizedAt: Scalars['AWSDateTime'];
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -4287,14 +4290,15 @@ export type MotionStateHistory = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
-  /** Timestamp of when the NAY side was fully staked */
-  naySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
-  /** Timestamp of when the YAY side was fully staked */
-  yaySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
+  naySideFullyStakedAt: Scalars['AWSDateTime'];
+  yaySideFullyStakedAt: Scalars['AWSDateTime'];
 };
 
 /** Input used to change the current state of a motion */
 export type MotionStateHistoryInput = {
+  allVotesRevealedAt: Scalars['AWSDateTime'];
+  allVotesSubmittedAt: Scalars['AWSDateTime'];
+  finalizedAt: Scalars['AWSDateTime'];
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -4305,10 +4309,8 @@ export type MotionStateHistoryInput = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
-  /** Timestamp of when the NAY side was fully staked */
-  naySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
-  /** Timestamp of when the YAY side was fully staked */
-  yaySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
+  naySideFullyStakedAt: Scalars['AWSDateTime'];
+  yaySideFullyStakedAt: Scalars['AWSDateTime'];
 };
 
 /** Root mutation type */
@@ -8256,8 +8258,8 @@ export type ColonyMotionFragment = {
     hasFailed: boolean;
     hasFailedNotFinalizable: boolean;
     inRevealPhase: boolean;
-    yaySideFullyStakedAt?: string | null;
-    naySideFullyStakedAt?: string | null;
+    yaySideFullyStakedAt: string;
+    naySideFullyStakedAt: string;
   };
 };
 
@@ -9306,8 +9308,8 @@ export type GetColonyMotionQuery = {
       hasFailed: boolean;
       hasFailedNotFinalizable: boolean;
       inRevealPhase: boolean;
-      yaySideFullyStakedAt?: string | null;
-      naySideFullyStakedAt?: string | null;
+      yaySideFullyStakedAt: string;
+      naySideFullyStakedAt: string;
     };
   } | null;
 };

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -218,7 +218,10 @@ export type ColonyTokensArgs = {
 /** Represents an action performed within a Colony */
 export type ColonyAction = {
   __typename?: 'ColonyAction';
-  /** The amount involved in the action, if applicable */
+  /**
+   * The amount involved in the action, if applicable
+   * In any case where network fee is involved, this amount excludes it
+   */
   amount?: Maybe<Scalars['String']>;
   /** The annotation associated with the action, if there is one */
   annotation?: Maybe<Annotation>;
@@ -267,6 +270,8 @@ export type ColonyAction = {
   motionDomainId?: Maybe<Scalars['Int']>;
   /** The internal database id of the motion */
   motionId?: Maybe<Scalars['ID']>;
+  /** The network fee amount, if applicable */
+  networkFee?: Maybe<Scalars['String']>;
   /** The resulting new Colony version, if applicable */
   newColonyVersion?: Maybe<Scalars['Int']>;
   /** The native id of the payment */
@@ -1076,6 +1081,7 @@ export type CreateColonyActionInput = {
   members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
+  networkFee?: InputMaybe<Scalars['String']>;
   newColonyVersion?: InputMaybe<Scalars['Int']>;
   paymentId?: InputMaybe<Scalars['Int']>;
   payments?: InputMaybe<Array<PaymentInput>>;
@@ -2225,6 +2231,7 @@ export type ModelColonyActionConditionInput = {
   members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
+  networkFee?: InputMaybe<ModelStringInput>;
   newColonyVersion?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelColonyActionConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionConditionInput>>>;
@@ -2262,6 +2269,7 @@ export type ModelColonyActionFilterInput = {
   members?: InputMaybe<ModelIdInput>;
   motionDomainId?: InputMaybe<ModelIntInput>;
   motionId?: InputMaybe<ModelIdInput>;
+  networkFee?: InputMaybe<ModelStringInput>;
   newColonyVersion?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelColonyActionFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyActionFilterInput>>>;
@@ -3417,6 +3425,7 @@ export type ModelSubscriptionColonyActionFilterInput = {
   members?: InputMaybe<ModelSubscriptionIdInput>;
   motionDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   motionId?: InputMaybe<ModelSubscriptionIdInput>;
+  networkFee?: InputMaybe<ModelSubscriptionStringInput>;
   newColonyVersion?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionColonyActionFilterInput>>>;
   paymentId?: InputMaybe<ModelSubscriptionIntInput>;
@@ -4268,8 +4277,6 @@ export type MotionStakesInput = {
 /** Quick access flages to check the current state of a motion in its lifecycle */
 export type MotionStateHistory = {
   __typename?: 'MotionStateHistory';
-  /** Timestamp at which the motion was fully staked on both sides */
-  bothSidesFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -4280,12 +4287,14 @@ export type MotionStateHistory = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
+  /** Timestamp of when the NAY side was fully staked */
+  naySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
+  /** Timestamp of when the YAY side was fully staked */
+  yaySideFullyStakedAt?: Maybe<Scalars['AWSDateTime']>;
 };
 
 /** Input used to change the current state of a motion */
 export type MotionStateHistoryInput = {
-  /** Timestamp at which the motion was fully staked on both sides */
-  bothSidesFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
   /** Whether the motion has failed */
   hasFailed: Scalars['Boolean'];
   /** Whether the motion has failed and cannot be finalized (e.g. if it doesn't get staked) */
@@ -4296,6 +4305,10 @@ export type MotionStateHistoryInput = {
   hasVoted: Scalars['Boolean'];
   /** Motion is in reveal phase (votes are being revealed) */
   inRevealPhase: Scalars['Boolean'];
+  /** Timestamp of when the NAY side was fully staked */
+  naySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
+  /** Timestamp of when the YAY side was fully staked */
+  yaySideFullyStakedAt?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
 /** Root mutation type */
@@ -5244,13 +5257,17 @@ export enum Network {
 
 export type Payment = {
   __typename?: 'Payment';
+  /** Payment amount, excluding network fee */
   amount: Scalars['String'];
+  /** Network fee amount */
+  networkFee?: Maybe<Scalars['String']>;
   recipientAddress: Scalars['String'];
   tokenAddress: Scalars['String'];
 };
 
 export type PaymentInput = {
   amount: Scalars['String'];
+  networkFee?: InputMaybe<Scalars['String']>;
   recipientAddress: Scalars['String'];
   tokenAddress: Scalars['String'];
 };
@@ -6413,6 +6430,7 @@ export enum SearchableColonyActionAggregateField {
   Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
+  NetworkFee = 'networkFee',
   NewColonyVersion = 'newColonyVersion',
   PaymentId = 'paymentId',
   PendingColonyMetadataId = 'pendingColonyMetadataId',
@@ -6457,6 +6475,7 @@ export type SearchableColonyActionFilterInput = {
   members?: InputMaybe<SearchableIdFilterInput>;
   motionDomainId?: InputMaybe<SearchableIntFilterInput>;
   motionId?: InputMaybe<SearchableIdFilterInput>;
+  networkFee?: InputMaybe<SearchableStringFilterInput>;
   newColonyVersion?: InputMaybe<SearchableIntFilterInput>;
   not?: InputMaybe<SearchableColonyActionFilterInput>;
   or?: InputMaybe<Array<InputMaybe<SearchableColonyActionFilterInput>>>;
@@ -6493,6 +6512,7 @@ export enum SearchableColonyActionSortableFields {
   Members = 'members',
   MotionDomainId = 'motionDomainId',
   MotionId = 'motionId',
+  NetworkFee = 'networkFee',
   NewColonyVersion = 'newColonyVersion',
   PaymentId = 'paymentId',
   PendingColonyMetadataId = 'pendingColonyMetadataId',
@@ -7472,6 +7492,7 @@ export type UpdateColonyActionInput = {
   members?: InputMaybe<Array<Scalars['ID']>>;
   motionDomainId?: InputMaybe<Scalars['Int']>;
   motionId?: InputMaybe<Scalars['ID']>;
+  networkFee?: InputMaybe<Scalars['String']>;
   newColonyVersion?: InputMaybe<Scalars['Int']>;
   paymentId?: InputMaybe<Scalars['Int']>;
   payments?: InputMaybe<Array<PaymentInput>>;
@@ -8235,7 +8256,8 @@ export type ColonyMotionFragment = {
     hasFailed: boolean;
     hasFailedNotFinalizable: boolean;
     inRevealPhase: boolean;
-    bothSidesFullyStakedAt?: string | null;
+    yaySideFullyStakedAt?: string | null;
+    naySideFullyStakedAt?: string | null;
   };
 };
 
@@ -9284,7 +9306,8 @@ export type GetColonyMotionQuery = {
       hasFailed: boolean;
       hasFailedNotFinalizable: boolean;
       inRevealPhase: boolean;
-      bothSidesFullyStakedAt?: string | null;
+      yaySideFullyStakedAt?: string | null;
+      naySideFullyStakedAt?: string | null;
     };
   } | null;
 };
@@ -9562,7 +9585,8 @@ export const ColonyMotion = gql`
       hasFailed
       hasFailedNotFinalizable
       inRevealPhase
-      bothSidesFullyStakedAt
+      yaySideFullyStakedAt
+      naySideFullyStakedAt
     }
     isDecision
     transactionHash

--- a/src/handlers/motions/index.ts
+++ b/src/handlers/motions/index.ts
@@ -4,3 +4,4 @@ export { default as handleMotionFinalized } from './motionFinalized';
 export { default as handleMotionRewardClaimed } from './motionRewardClaimed';
 export { default as handleMotionVoteSubmitted } from './motionVoteSubmitted';
 export { default as handleMotionVoteRevealed } from './motionVoteRevealed';
+export { default as handleMotionEventSet } from './motionEventSet';

--- a/src/handlers/motions/motionEventSet/index.ts
+++ b/src/handlers/motions/motionEventSet/index.ts
@@ -1,15 +1,51 @@
 import { ContractEvent } from '~types';
-import { verbose } from '~utils';
+import { verbose, getVotingClient } from '~utils';
+
+import {
+  getMotionDatabaseId,
+  getMotionFromDB,
+  updateMotionInDB,
+} from '../helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const {
     colonyAddress,
-    args: { motionId, eventIndex },
+    args: { motionId, eventIndex, timestamp },
   } = event;
 
   if (!colonyAddress) {
     return;
   }
 
+  const votingClient = await getVotingClient(colonyAddress);
+
+  if (!votingClient) {
+    return;
+  }
+
+  const { chainId } = await votingClient.provider.getNetwork();
+  const motionDatabaseId = getMotionDatabaseId(
+    chainId,
+    votingClient.address,
+    motionId,
+  );
+  const motion = await getMotionFromDB(motionDatabaseId);
+
+  if (motion) {
+    await updateMotionInDB({
+      ...motion,
+      motionStateHistory: {
+        ...motion.motionStateHistory,
+        allVotesSubmittedAt:
+          eventIndex === 1
+            ? new Date(timestamp * 1000).toISOString()
+            : motion.motionStateHistory.allVotesSubmittedAt,
+        allVotesRevealedAt:
+          eventIndex === 2
+            ? new Date(timestamp * 1000).toISOString()
+            : motion.motionStateHistory.allVotesRevealedAt,
+      },
+    });
+  }
   verbose(`Motion: ${motionId} has advanced from ${eventIndex}`);
 };

--- a/src/handlers/motions/motionEventSet/index.ts
+++ b/src/handlers/motions/motionEventSet/index.ts
@@ -10,7 +10,8 @@ import {
 export default async (event: ContractEvent): Promise<void> => {
   const {
     colonyAddress,
-    args: { motionId, eventIndex, timestamp },
+    args: { motionId, eventIndex },
+    timestamp,
   } = event;
 
   if (!colonyAddress) {

--- a/src/handlers/motions/motionEventSet/index.ts
+++ b/src/handlers/motions/motionEventSet/index.ts
@@ -1,0 +1,15 @@
+import { ContractEvent } from '~types';
+import { verbose } from '~utils';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const {
+    colonyAddress,
+    args: { motionId, eventIndex },
+  } = event;
+
+  if (!colonyAddress) {
+    return;
+  }
+
+  verbose(`Motion: ${motionId} has advanced from ${eventIndex}`);
+};

--- a/src/handlers/motions/motionEventSet/index.ts
+++ b/src/handlers/motions/motionEventSet/index.ts
@@ -36,14 +36,12 @@ export default async (event: ContractEvent): Promise<void> => {
       ...motion,
       motionStateHistory: {
         ...motion.motionStateHistory,
-        allVotesSubmittedAt:
-          eventIndex === '1'
-            ? new Date(timestamp * 1000).toISOString()
-            : motion.motionStateHistory.allVotesSubmittedAt,
-        allVotesRevealedAt:
-          eventIndex === '2'
-            ? new Date(timestamp * 1000).toISOString()
-            : motion.motionStateHistory.allVotesRevealedAt,
+        allVotesSubmittedAt: eventIndex.eq(1)
+          ? new Date(timestamp * 1000).toISOString()
+          : motion.motionStateHistory.allVotesSubmittedAt,
+        allVotesRevealedAt: eventIndex.eq(2)
+          ? new Date(timestamp * 1000).toISOString()
+          : motion.motionStateHistory.allVotesRevealedAt,
       },
     });
   }

--- a/src/handlers/motions/motionEventSet/index.ts
+++ b/src/handlers/motions/motionEventSet/index.ts
@@ -37,11 +37,11 @@ export default async (event: ContractEvent): Promise<void> => {
       motionStateHistory: {
         ...motion.motionStateHistory,
         allVotesSubmittedAt:
-          eventIndex === 1
+          eventIndex === '1'
             ? new Date(timestamp * 1000).toISOString()
             : motion.motionStateHistory.allVotesSubmittedAt,
         allVotesRevealedAt:
-          eventIndex === 2
+          eventIndex === '2'
             ? new Date(timestamp * 1000).toISOString()
             : motion.motionStateHistory.allVotesRevealedAt,
       },

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -24,6 +24,7 @@ export default async (event: ContractEvent): Promise<void> => {
     transactionHash,
     args: { motionId, action },
     blockNumber,
+    timestamp,
   } = event;
 
   if (!colonyAddress) {
@@ -88,6 +89,10 @@ export default async (event: ContractEvent): Promise<void> => {
       ...finalizedMotion,
       stakerRewards: updatedStakerRewards,
       isFinalized: true,
+      motionStateHistory: {
+        ...finalizedMotion.motionStateHistory,
+        finalizedAt: new Date(timestamp * 1000).toISOString(),
+      },
     };
 
     await updateMotionInDB(updatedMotionData, newMotionMessages);

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -92,7 +92,7 @@ export default async (event: ContractEvent): Promise<void> => {
           ...stakedMotion.motionStateHistory,
           bothSidesFullyStakedAt: bothSidesFullyStaked
             ? new Date(timestamp * 1000).toISOString()
-            : undefined,
+            : null,
         },
       },
       newMotionMessages,

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -78,12 +78,22 @@ export default async (event: ContractEvent): Promise<void> => {
       amount,
     });
 
+    const bothSidesFullyStaked =
+      requiredStake.eq(motionStakes.raw.yay) &&
+      requiredStake.eq(motionStakes.raw.nay);
+
     await updateMotionInDB(
       {
         ...stakedMotion,
         usersStakes: updatedUserStakes,
         motionStakes,
         remainingStakes,
+        motionStateHistory: {
+          ...stakedMotion.motionStateHistory,
+          bothSidesFullyStakedAt: bothSidesFullyStaked
+            ? new Date(timestamp * 1000).toISOString()
+            : undefined,
+        },
       },
       newMotionMessages,
       showInActionsList,

--- a/src/handlers/motions/motionVoteRevealed/index.ts
+++ b/src/handlers/motions/motionVoteRevealed/index.ts
@@ -12,7 +12,6 @@ export default async (event: ContractEvent): Promise<void> => {
     colonyAddress,
     args: { motionId, voter, vote },
     blockNumber,
-    timestamp,
   } = event;
 
   if (!colonyAddress) {
@@ -67,13 +66,6 @@ export default async (event: ContractEvent): Promise<void> => {
           [MotionSide.NAY]: nayVotePercentage.toString(),
           [MotionSide.YAY]: yayVotePercentage.toString(),
         },
-      },
-      motionStateHistory: {
-        ...revealedMotion.motionStateHistory,
-        allVotesRevealedAt:
-          nayVotePercentage.eq(100) && yayVotePercentage.eq(100)
-            ? new Date(timestamp * 1000).toISOString()
-            : null,
       },
     });
 

--- a/src/handlers/motions/motionVoteRevealed/index.ts
+++ b/src/handlers/motions/motionVoteRevealed/index.ts
@@ -12,6 +12,7 @@ export default async (event: ContractEvent): Promise<void> => {
     colonyAddress,
     args: { motionId, voter, vote },
     blockNumber,
+    timestamp,
   } = event;
 
   if (!colonyAddress) {
@@ -66,6 +67,13 @@ export default async (event: ContractEvent): Promise<void> => {
           [MotionSide.NAY]: nayVotePercentage.toString(),
           [MotionSide.YAY]: yayVotePercentage.toString(),
         },
+      },
+      motionStateHistory: {
+        ...revealedMotion.motionStateHistory,
+        allVotesRevealedAt:
+          nayVotePercentage.eq(100) && yayVotePercentage.eq(100)
+            ? new Date(timestamp * 1000).toISOString()
+            : null,
       },
     });
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -69,6 +69,7 @@ export enum ContractEventsSignatures {
   MotionRewardClaimed = 'MotionRewardClaimed(uint256,address,uint256,uint256)',
   MotionVoteSubmitted = 'MotionVoteSubmitted(uint256,address)',
   MotionVoteRevealed = 'MotionVoteRevealed(uint256,address,uint256)',
+  MotionEventSet = 'MotionEventSet(uint256,uint256)',
 
   // Expenditures
   ExpenditureGlobalClaimDelaySet = 'ExpenditureGlobalClaimDelaySet(address,uint256)',


### PR DESCRIPTION
This PR adds a bunch of timestamps to display the time when a motion phase was started/ended. These timestamps are displayed on the motion step pills, all the variations can be observed here: https://www.notion.so/colony/Actions-775cb0e78eb44783a6f28702b7a9dc33#72f018e16a234ef5944613c02ca1846a

I've added a `MotionEventSet` handler for timestamps that weren't easy, or outright not possible to get with the other events.

CDapp PR counterpart: https://github.com/JoinColony/colonyCDapp/pull/1625