### PR TITLE
Refactor verified contributors and whitelist

### DIFF
--- a/src/graphql/fragments/colony.graphql
+++ b/src/graphql/fragments/colony.graphql
@@ -42,13 +42,10 @@ fragment ColonyMetadata on ColonyMetadata {
     oldDisplayName
     newDisplayName
     hasAvatarChanged
-    hasWhitelistChanged
     haveTokensChanged
     hasDescriptionChanged
     haveExternalLinksChanged
   }
-  isWhitelistActivated
-  whitelistedAddresses
   modifiedTokenAddresses {
     added
     removed

--- a/src/handlers/colonies/colonyAdded.ts
+++ b/src/handlers/colonies/colonyAdded.ts
@@ -79,6 +79,8 @@ export default async (event: ContractEvent): Promise<void> => {
     input: {
       id: getColonyContributorId(colonyAddress, colonyFounderAddress),
       isWatching: true,
+      // @ts-expect-error
+      isWhitelisted: true,
     },
   });
 

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -195,7 +195,6 @@ const linkPendingColonyMetadataWithColony = async (
   const {
     haveTokensChanged,
     hasAvatarChanged,
-    hasWhitelistChanged,
     newDisplayName,
     oldDisplayName,
     hasDescriptionChanged,
@@ -215,15 +214,6 @@ const linkPendingColonyMetadataWithColony = async (
     // If avatar has changed, update avatar and thumbnail
     updatedMetadata.avatar = pendingColonyMetadata.avatar;
     updatedMetadata.thumbnail = pendingColonyMetadata.thumbnail;
-  }
-
-  if (hasWhitelistChanged) {
-    // If whitelist has changed, update whitelistedAddresses and isWhitelistActivated
-    updatedMetadata.isWhitelistActivated =
-      pendingColonyMetadata.isWhitelistActivated;
-
-    updatedMetadata.whitelistedAddresses =
-      pendingColonyMetadata.whitelistedAddresses;
   }
 
   if (newDisplayName !== oldDisplayName) {


### PR DESCRIPTION
# Description

This PR removes the obsolete whitelist code on the colony (both in the metadata and on the colony directly) and replaces it with `isVerified` and `isWhitelisted` on the colony contributor model