### PR TITLE
Read contract data at the time the event happened

### DIFF
--- a/src/handlers/actions/createDomain.ts
+++ b/src/handlers/actions/createDomain.ts
@@ -14,7 +14,7 @@ import {
 } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
-  const { contractAddress: colonyAddress } = event;
+  const { contractAddress: colonyAddress, blockNumber } = event;
   const { domainId, agent: initiatorAddress } = event.args;
   const nativeDomainId = toNumber(domainId);
   const databaseDomainId = getDomainDatabaseId(colonyAddress, nativeDomainId);
@@ -25,7 +25,9 @@ export default async (event: ContractEvent): Promise<void> => {
     return;
   }
 
-  const [skillId, fundingPotId] = await colonyClient.getDomain(nativeDomainId);
+  const [skillId, fundingPotId] = await colonyClient.getDomain(nativeDomainId, {
+    blockTag: blockNumber,
+  });
 
   await mutate<CreateDomainMutation, CreateDomainMutationVariables>(
     CreateDomainDocument,

--- a/src/handlers/actions/moveFunds.ts
+++ b/src/handlers/actions/moveFunds.ts
@@ -25,7 +25,7 @@ export default async (event: ContractEvent): Promise<void> => {
     return;
   }
 
-  const { contractAddress: colonyAddress } = event;
+  const { contractAddress: colonyAddress, blockNumber } = event;
   const {
     agent: initiatorAddress,
     token: tokenAddress,
@@ -43,8 +43,12 @@ export default async (event: ContractEvent): Promise<void> => {
   }
 
   if (isDomainFromFundingPotSupported(colonyClient)) {
-    fromDomainId = await colonyClient.getDomainFromFundingPot(fromPot);
-    toDomainId = await colonyClient.getDomainFromFundingPot(toPot);
+    fromDomainId = await colonyClient.getDomainFromFundingPot(fromPot, {
+      blockTag: blockNumber,
+    });
+    toDomainId = await colonyClient.getDomainFromFundingPot(toPot, {
+      blockTag: blockNumber,
+    });
   }
 
   await writeActionFromEvent(event, colonyAddress, {

--- a/src/handlers/actions/unlockToken.ts
+++ b/src/handlers/actions/unlockToken.ts
@@ -10,7 +10,7 @@ import {
 } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
-  const { contractAddress: colonyAddress } = event;
+  const { contractAddress: colonyAddress, blockNumber } = event;
   const { agent: initiatorAddress } = event.args;
 
   const colonyClient = await getCachedColonyClient(colonyAddress);
@@ -19,7 +19,7 @@ export default async (event: ContractEvent): Promise<void> => {
     return;
   }
 
-  const tokenAddress = await colonyClient.getToken();
+  const tokenAddress = await colonyClient.getToken({ blockTag: blockNumber });
 
   // update all colonies that have this token as their native token
   await updateColoniesNativeTokenStatuses(tokenAddress, { unlocked: true });

--- a/src/handlers/expenditures/paymentTokenUpdated.ts
+++ b/src/handlers/expenditures/paymentTokenUpdated.ts
@@ -10,7 +10,6 @@ import {
 import { getStreamingPaymentFromDB } from './helpers';
 
 export default async (event: ContractEvent): Promise<void> => {
-  console.log(event);
   const { colonyAddress } = event;
   const { streamingPaymentId, token: tokenAddress, amount } = event.args;
   const convertedNativeId = toNumber(streamingPaymentId);

--- a/src/handlers/expenditures/streamingPaymentCreated.ts
+++ b/src/handlers/expenditures/streamingPaymentCreated.ts
@@ -13,7 +13,7 @@ import {
 } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
-  const { colonyAddress } = event;
+  const { colonyAddress, blockNumber } = event;
   const { streamingPaymentId } = event.args;
   const convertedNativeId = toNumber(streamingPaymentId);
 
@@ -30,6 +30,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
   const streamingPayment = await streamingPaymentsClient.getStreamingPayment(
     streamingPaymentId,
+    { blockTag: blockNumber },
   );
   if (!streamingPayment) {
     return;

--- a/src/handlers/extensions/extensionInstalled.ts
+++ b/src/handlers/extensions/extensionInstalled.ts
@@ -13,10 +13,12 @@ import { writeExtensionFromEvent } from '~utils';
 import { updateExtensionCount } from '~utils/extensions';
 
 export default async (event: ContractEvent): Promise<void> => {
+  const { blockNumber } = event;
   const { extensionId: extensionHash, colony } = event.args;
   const extensionAddress = await networkClient.getExtensionInstallation(
     extensionHash,
     colony,
+    { blockTag: blockNumber },
   );
 
   await writeExtensionFromEvent(event, extensionAddress);

--- a/src/handlers/motions/motionCreated/handlers/mintTokens.ts
+++ b/src/handlers/motions/motionCreated/handlers/mintTokens.ts
@@ -12,6 +12,7 @@ export const handleMintTokensMotion = async (
   const {
     colonyAddress,
     args: { domainId },
+    blockNumber,
   } = event;
   if (!colonyAddress) {
     return;
@@ -19,7 +20,7 @@ export const handleMintTokensMotion = async (
 
   const { name, args: actionArgs } = parsedAction;
   const amount = actionArgs[0].toString();
-  const tokenAddress = await getColonyTokenAddress(colonyAddress);
+  const tokenAddress = await getColonyTokenAddress(colonyAddress, blockNumber);
   await createMotionInDB(event, {
     type: motionNameMapping[name],
     tokenAddress,

--- a/src/handlers/motions/motionCreated/handlers/moveFunds.ts
+++ b/src/handlers/motions/motionCreated/handlers/moveFunds.ts
@@ -16,7 +16,7 @@ export const handleMoveFundsMotion = async (
   parsedAction: TransactionDescription,
   gasEstimate: BigNumber,
 ): Promise<void> => {
-  const { colonyAddress } = event;
+  const { colonyAddress, blockNumber } = event;
 
   if (!colonyAddress) {
     return;
@@ -30,7 +30,7 @@ export const handleMoveFundsMotion = async (
     return;
   }
 
-  const colonyVersion = await colonyClient.version();
+  const colonyVersion = await colonyClient.version({ blockTag: blockNumber });
 
   // There are two moveFundsBetweenPots actions, one pre colony version 7 and one post.
   let fromPot: BigNumber,
@@ -49,8 +49,12 @@ export const handleMoveFundsMotion = async (
   let toDomainId: BigNumber | undefined;
 
   if (isDomainFromFundingPotSupported(colonyClient)) {
-    fromDomainId = await colonyClient.getDomainFromFundingPot(fromPot);
-    toDomainId = await colonyClient.getDomainFromFundingPot(toPot);
+    fromDomainId = await colonyClient.getDomainFromFundingPot(fromPot, {
+      blockTag: blockNumber,
+    });
+    toDomainId = await colonyClient.getDomainFromFundingPot(toPot, {
+      blockTag: blockNumber,
+    });
   }
 
   await createMotionInDB(event, {

--- a/src/handlers/motions/motionCreated/handlers/unlockToken.ts
+++ b/src/handlers/motions/motionCreated/handlers/unlockToken.ts
@@ -10,13 +10,13 @@ export const handleUnlockTokenMotion = async (
   parsedAction: TransactionDescription,
   gasEstimate: BigNumber,
 ): Promise<void> => {
-  const { colonyAddress } = event;
+  const { colonyAddress, blockNumber } = event;
   if (!colonyAddress) {
     return;
   }
 
   const { name } = parsedAction;
-  const tokenAddress = await getColonyTokenAddress(colonyAddress);
+  const tokenAddress = await getColonyTokenAddress(colonyAddress, blockNumber);
 
   await createMotionInDB(event, {
     type: motionNameMapping[name],

--- a/src/handlers/motions/motionCreated/motionCreated.ts
+++ b/src/handlers/motions/motionCreated/motionCreated.ts
@@ -63,6 +63,16 @@ export default async (event: ContractEvent): Promise<void> => {
   let gasEstimate: BigNumber;
 
   const estimateMotionGas = async (): Promise<string> =>
+    /*
+     * @NOTE Express casting required here since colonyJS forces it's own types internally
+     * Even though we instantiate the initial network client with a JsonRpcProvider, colonyJS
+     * will internally cast it to a BaseProvider which is a generic type that doesn't declare
+     * all the methods actually available on the provider
+     *
+     * Alternatively, we could just import our provider directly and use that instead
+     *
+     * Ultimately it's the same thing as the provider instance is the same
+     */
     await (colonyClient.provider as JsonRpcProvider).send('eth_estimateGas', [
       {
         from: votingReputationClient.address,

--- a/src/handlers/motions/motionFinalized/helpers.ts
+++ b/src/handlers/motions/motionFinalized/helpers.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
+import { BlockTag } from '@ethersproject/abstract-provider';
 import { AnyVotingReputationClient, Extension } from '@colony/colony-js';
 
 import { ColonyOperations, MotionVote } from '~types';
@@ -38,6 +39,7 @@ export const getStakerReward = async (
   motionId: string,
   userAddress: string,
   votingReputationClient: AnyVotingReputationClient,
+  blockNumber: BlockTag = 'latest',
 ): Promise<StakerReward> => {
   /*
    * If **anyone** staked on a side, calling the rewards function returns 0 if there's no reward (even for
@@ -55,6 +57,7 @@ export const getStakerReward = async (
       motionId,
       userAddress,
       MotionVote.YAY,
+      { blockTag: blockNumber },
     );
   } catch (error) {
     // We don't care to catch the error since we fallback to it's initial value
@@ -64,6 +67,7 @@ export const getStakerReward = async (
       motionId,
       userAddress,
       MotionVote.NAY,
+      { blockTag: blockNumber },
     );
   } catch (error) {
     // silent error

--- a/src/handlers/motions/motionFinalized/motionFinalized.ts
+++ b/src/handlers/motions/motionFinalized/motionFinalized.ts
@@ -22,6 +22,7 @@ export default async (event: ContractEvent): Promise<void> => {
     logIndex,
     transactionHash,
     args: { motionId, action },
+    blockNumber,
   } = event;
 
   if (!colonyAddress) {
@@ -63,7 +64,12 @@ export default async (event: ContractEvent): Promise<void> => {
     const updatedStakerRewards = await Promise.all(
       usersStakes.map(
         async ({ address: userAddress }) =>
-          await getStakerReward(motionId, userAddress, votingClient),
+          await getStakerReward(
+            motionId,
+            userAddress,
+            votingClient,
+            blockNumber,
+          ),
       ),
     );
 

--- a/src/handlers/motions/motionStaked/motionStaked.ts
+++ b/src/handlers/motions/motionStaked/motionStaked.ts
@@ -22,6 +22,7 @@ export default async (event: ContractEvent): Promise<void> => {
     transactionHash,
     args: { vote, amount, staker, motionId },
     timestamp,
+    blockNumber,
   } = event;
 
   if (!colonyAddress) {
@@ -36,8 +37,12 @@ export default async (event: ContractEvent): Promise<void> => {
     return;
   }
 
-  const totalStakeFraction = await votingClient.getTotalStakeFraction();
-  const { skillRep, stakes } = await votingClient.getMotion(motionId);
+  const totalStakeFraction = await votingClient.getTotalStakeFraction({
+    blockTag: blockNumber,
+  });
+  const { skillRep, stakes } = await votingClient.getMotion(motionId, {
+    blockTag: blockNumber,
+  });
 
   const requiredStake = getRequiredStake(skillRep, totalStakeFraction);
   const motionStakes = getMotionStakes(requiredStake, stakes, vote);

--- a/src/handlers/motions/motionVoteRevealed/index.ts
+++ b/src/handlers/motions/motionVoteRevealed/index.ts
@@ -11,6 +11,7 @@ export default async (event: ContractEvent): Promise<void> => {
   const {
     colonyAddress,
     args: { motionId, voter, vote },
+    blockNumber,
   } = event;
 
   if (!colonyAddress) {
@@ -25,7 +26,7 @@ export default async (event: ContractEvent): Promise<void> => {
 
   const {
     votes: [nayVotes, yayVotes],
-  } = await votingClient.getMotion(motionId);
+  } = await votingClient.getMotion(motionId, { blockTag: blockNumber });
   const { chainId } = await votingClient.provider.getNetwork();
   const motionDatabaseId = getMotionDatabaseId(
     chainId,

--- a/src/handlers/motions/motionVoteSubmitted/index.ts
+++ b/src/handlers/motions/motionVoteSubmitted/index.ts
@@ -11,6 +11,7 @@ export default async (event: ContractEvent): Promise<void> => {
   const {
     colonyAddress,
     args: { motionId, voter },
+    blockNumber,
   } = event;
 
   if (!colonyAddress) {
@@ -23,7 +24,9 @@ export default async (event: ContractEvent): Promise<void> => {
     return;
   }
 
-  const { repSubmitted } = await votingClient.getMotion(motionId);
+  const { repSubmitted } = await votingClient.getMotion(motionId, {
+    blockTag: blockNumber,
+  });
   const { chainId } = await votingClient.provider.getNetwork();
   const motionDatabaseId = getMotionDatabaseId(
     chainId,

--- a/src/handlers/tokens/setTokenAuthority.ts
+++ b/src/handlers/tokens/setTokenAuthority.ts
@@ -8,7 +8,7 @@ import {
 } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
-  const { contractAddress } = event;
+  const { contractAddress, blockNumber } = event;
 
   const client = await getCachedTokenClient(contractAddress);
 
@@ -29,14 +29,28 @@ export default async (event: ContractEvent): Promise<void> => {
       client.tokenClientType === TokenClientType.ColonyLegacy
     ) {
       try {
-        await client.estimateGas.unlock({ from: colonyAddress });
+        await client.provider.call(
+          {
+            from: colonyAddress,
+            to: client.address,
+            data: client.interface.encodeFunctionData('unlock()'),
+          },
+          blockNumber,
+        );
         unlockable = true;
       } catch (error) {
         // silent
       }
 
       try {
-        await client.estimateGas['mint(uint256)'](1, { from: colonyAddress });
+        await client.provider.call(
+          {
+            from: colonyAddress,
+            to: client.address,
+            data: client.interface.encodeFunctionData('mint(uint256)', [1]),
+          },
+          blockNumber,
+        );
         mintable = true;
       } catch (error) {
         // silent

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1,3 +1,5 @@
+import { BlockTag } from '@ethersproject/abstract-provider';
+
 import { mutate, query } from '~amplifyClient';
 
 import { getCachedColonyClient } from './clients';
@@ -26,11 +28,12 @@ import { Colony as FullColony } from '~graphql/generated';
 
 export const getColonyTokenAddress = async (
   colonyAddress: string,
+  blockNumber: BlockTag = 'latest',
 ): Promise<string | undefined> => {
   const colonyClient = await getCachedColonyClient(colonyAddress);
 
   if (colonyClient) {
-    const tokenAddress = await colonyClient.getToken();
+    const tokenAddress = await colonyClient.getToken({ blockTag: blockNumber });
     return tokenAddress;
   }
 };


### PR DESCRIPTION
This PR refactors **all** the contract read calls we make in the block ingestor _(ie: every time we call a method on an instantiated `colonyJS` client)_ by making sure the data we read is historically correct to the time the event actually happened.

This is accomplished by getting the block number of the specific event we handle, and passing it in the [CallOverrides](https://docs.ethers.org/v5/api/contract/contract/#Contract-functionsCall) options object

This way we ensure that every time we read a specific piece of data from the contracts, be it now, or in the past, it will have always the exact same, correct value.

This change in this PR helps avoid various race conditions that will start happening once the block ingestor is under heavier load, as well as giving the block ingestor the ability to be properly sync'd from a past block in time, up to the latest one.