### PR TITLE
Restart if cannot fetch stats database data / API

### DIFF
--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -53,8 +53,19 @@ export const updateStats = async (
 // This exists as a function to prevent accidental overwriting of the `stats` variable
 export const getStats = (): typeof stats => ({ ...stats });
 
-export const getLastBlockNumber = (): number =>
-  Number.isInteger(stats.lastBlockNumber) ? Number(stats.lastBlockNumber) : 1;
+export const getLastBlockNumber = (): number => {
+  if (Number.isInteger(stats.lastBlockNumber)) {
+    return Number(stats.lastBlockNumber);
+  }
+  /*
+   * @NOTE This prevents accidental database stats overwriting if the API / GraphQL
+   * endpoint is not accessible
+   *
+   * It will throw the block ingestor (the pod that it's running on) into an restart
+   * loop until the API is accessible again
+   */
+  throw new Error('Could not get last block number from stats. Aborting.');
+};
 
 export const setLastBlockNumber = (lastBlockNumber: number): void => {
   updateStats({ lastBlockNumber });


### PR DESCRIPTION
This PR fixes a issue we encountered in production, where the connection to the GraphQL database went down, resulting in the block ingestor not being able to fetch the latest processed block, falling back to block one, and starting it's tracking from there.

Once that connection was restored, it continued processing the wrong block, and even worst, it overwritten that data in the production database causing confusion and errors

The approach to this is to just throw if the latest block cannot be fetched, meaning the kubernetes pod that is running this service will trigger a restart, and will continue with it's restart loop until the connection to the API / database is restored.

This is how we actually handle all the block ingestor major errors, be they with events or blocks, or handlers

Resolves #157 