### PR TITLE
[Verified members] feat: block ingestor can now catch MetadataDelta events and parse operations, implement add verified members

### DIFF
--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -101,6 +101,7 @@ export const setupListenersForColony = (
     ContractEventsSignatures.ExpenditurePayoutClaimed,
     ContractEventsSignatures.AnnotateTransaction,
     ContractEventsSignatures.ArbitraryTransaction,
+    ContractEventsSignatures.ColonyMetadataDelta,
   ];
 
   colonyEvents.forEach((eventSignature) =>

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -350,7 +350,6 @@ export default async (event: ContractEvent): Promise<void> => {
       return;
     }
 
-    // All ColonyMetadataDelta events
     case ContractEventsSignatures.ColonyMetadataDelta:
       await handleColonyMetadataDelta(event);
       return;

--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -51,6 +51,7 @@ import {
   handleExpenditureMadeViaStake,
   handlePaymentTokenUpdated,
   handleSetTokenAuthority,
+  handleColonyMetadataDelta,
 } from './handlers';
 
 dotenv.config();
@@ -348,6 +349,11 @@ export default async (event: ContractEvent): Promise<void> => {
       await handleSetTokenAuthority(event);
       return;
     }
+
+    // All ColonyMetadataDelta events
+    case ContractEventsSignatures.ColonyMetadataDelta:
+      await handleColonyMetadataDelta(event);
+      return;
 
     default: {
       return;

--- a/src/graphql/mutations/verifiedMembers.graphql
+++ b/src/graphql/mutations/verifiedMembers.graphql
@@ -1,0 +1,13 @@
+query GetVerifiedMember($colonyAddress: ID!, $userAddress: ID!) {
+  getVerifiedMember(colonyAddress: $colonyAddress, userAddress: $userAddress) {
+    userAddress
+    colonyAddress
+  }
+}
+
+mutation CreateVerifiedMember($input: CreateVerifiedMemberInput!) {
+  createVerifiedMember(input: $input) {
+    userAddress
+    colonyAddress
+  }
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -6,3 +6,4 @@ export * from './motions';
 export * from './expenditures';
 export * from './reputationMiningCycle';
 export * from './tokens';
+export * from './metadataDelta';

--- a/src/handlers/metadataDelta/handlers/addVerifiedMembers.ts
+++ b/src/handlers/metadataDelta/handlers/addVerifiedMembers.ts
@@ -1,0 +1,67 @@
+import { mutate, query } from '~amplifyClient';
+import {
+  ColonyActionType,
+  CreateVerifiedMemberDocument,
+  CreateVerifiedMemberMutation,
+  CreateVerifiedMemberMutationVariables,
+  GetVerifiedMemberDocument,
+  GetVerifiedMemberQuery,
+  GetVerifiedMemberQueryVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { writeActionFromEvent } from '~utils';
+import {
+  AddVerifiedMembersOperation,
+  MetadataDeltaActionType,
+  MetadataDeltaOperation,
+} from '../types';
+
+const isAddVerifiedMembersOperation = (
+  operation: MetadataDeltaOperation,
+): operation is AddVerifiedMembersOperation => {
+  return (
+    operation.type === MetadataDeltaActionType.ADD_VERIFIED_MEMBERS &&
+    operation.payload !== undefined &&
+    Array.isArray(operation.payload)
+  );
+};
+
+export const handleAddVerifiedMembers = async (
+  event: ContractEvent,
+  operation: MetadataDeltaOperation,
+): Promise<void> => {
+  if (isAddVerifiedMembersOperation(operation)) {
+    const { contractAddress: colonyAddress } = event;
+    const { agent: initiatorAddress } = event.args;
+
+    await Promise.all(
+      operation.payload.map(async (userAddress) => {
+        const item = await query<
+          GetVerifiedMemberQuery,
+          GetVerifiedMemberQueryVariables
+        >(GetVerifiedMemberDocument, { colonyAddress, userAddress });
+
+        const verifiedMemberData = item?.data?.getVerifiedMember;
+
+        if (verifiedMemberData !== undefined && verifiedMemberData !== null) {
+          throw new Error(
+            `User ${userAddress} already a verified member of the colony ${colonyAddress}`,
+          );
+        }
+
+        await mutate<
+          CreateVerifiedMemberMutation,
+          CreateVerifiedMemberMutationVariables
+        >(CreateVerifiedMemberDocument, {
+          input: { colonyAddress, userAddress },
+        });
+      }),
+    );
+
+    await writeActionFromEvent(event, colonyAddress, {
+      type: ColonyActionType.AddVerifiedMembers,
+      initiatorAddress,
+      members: operation.payload,
+    });
+  }
+};

--- a/src/handlers/metadataDelta/index.ts
+++ b/src/handlers/metadataDelta/index.ts
@@ -1,0 +1,1 @@
+export { default as handleColonyMetadataDelta } from './metadataDelta';

--- a/src/handlers/metadataDelta/metadataDelta.ts
+++ b/src/handlers/metadataDelta/metadataDelta.ts
@@ -1,16 +1,10 @@
 import { ContractEvent } from '~types';
 import { verbose } from '~utils';
-import { parseOperation } from './utils';
-import { MetadataDeltaOperationType } from './types';
+import { isAddVerifiedMembersOperation, parseOperation } from './utils';
 import { handleAddVerifiedMembers } from './handlers/addVerifiedMembers';
 
 export default async (event: ContractEvent): Promise<void> => {
   const operationString = event.args.metadata;
-
-  if (!operationString) {
-    verbose('Unable to get operation for ColonyMetadataDelta event');
-    return;
-  }
 
   const operation = parseOperation(operationString);
 
@@ -18,9 +12,10 @@ export default async (event: ContractEvent): Promise<void> => {
     return;
   }
 
-  switch (operation.type) {
-    case MetadataDeltaOperationType.ADD_VERIFIED_MEMBERS:
-      await handleAddVerifiedMembers(event, operation);
-      break;
+  if (isAddVerifiedMembersOperation(operation)) {
+    await handleAddVerifiedMembers(event, operation);
+    return;
   }
+
+  verbose('Unknown operation type: ', operation);
 };

--- a/src/handlers/metadataDelta/metadataDelta.ts
+++ b/src/handlers/metadataDelta/metadataDelta.ts
@@ -1,28 +1,25 @@
 import { ContractEvent } from '~types';
 import { verbose } from '~utils';
-import { isMetadataDeltaOperation, parseOperation } from './utils';
-import { MetadataDeltaActionType } from './types';
+import { parseOperation } from './utils';
+import { MetadataDeltaOperationType } from './types';
 import { handleAddVerifiedMembers } from './handlers/addVerifiedMembers';
 
 export default async (event: ContractEvent): Promise<void> => {
-  const operationString = event.args[1];
+  const operationString = event.args.metadata;
 
   if (!operationString) {
     verbose('Unable to get operation for ColonyMetadataDelta event');
+    return;
   }
 
   const operation = parseOperation(operationString);
 
-  if (operation === null || !isMetadataDeltaOperation(operation)) {
-    verbose(
-      'Operation does not conform to MetadataDeltaOperation type: ',
-      operation,
-    );
+  if (operation === null) {
     return;
   }
 
   switch (operation.type) {
-    case MetadataDeltaActionType.ADD_VERIFIED_MEMBERS:
+    case MetadataDeltaOperationType.ADD_VERIFIED_MEMBERS:
       await handleAddVerifiedMembers(event, operation);
       break;
   }

--- a/src/handlers/metadataDelta/metadataDelta.ts
+++ b/src/handlers/metadataDelta/metadataDelta.ts
@@ -1,0 +1,71 @@
+import {
+  ColonyActionType,
+  CreateVerifiedMemberDocument,
+  CreateVerifiedMemberMutation,
+  CreateVerifiedMemberMutationVariables,
+  GetVerifiedMemberDocument,
+  GetVerifiedMemberQuery,
+  GetVerifiedMemberQueryVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { verbose, writeActionFromEvent } from '~utils';
+import {
+  isAddVerifiedMembersOperation,
+  isMetadataDeltaOperation,
+  parseOperation,
+} from './utils';
+import { mutate, query } from '~amplifyClient';
+
+export default async (event: ContractEvent): Promise<void> => {
+  const { contractAddress: colonyAddress } = event;
+  const { agent: initiatorAddress } = event.args;
+  const operationString = event.args[1];
+
+  if (!operationString) {
+    verbose('Unable to get operation for ColonyMetadataDelta event');
+  }
+
+  const operation = parseOperation(operationString);
+
+  if (!isMetadataDeltaOperation(operation)) {
+    verbose(
+      'Operation does not conform to MetadataDeltaOperation type: ',
+      operation,
+    );
+    throw new Error('Unknown operation format');
+  }
+
+  if (isAddVerifiedMembersOperation(operation)) {
+    await Promise.all(
+      operation.members.map(async (userAddress) => {
+        const item = await query<
+          GetVerifiedMemberQuery,
+          GetVerifiedMemberQueryVariables
+        >(GetVerifiedMemberDocument, { colonyAddress, userAddress });
+
+        const verifiedMemberData = item?.data?.getVerifiedMember;
+
+        if (verifiedMemberData !== undefined && verifiedMemberData !== null) {
+          throw new Error(
+            `User ${userAddress} already a verified member of the colony ${colonyAddress}`,
+          );
+        }
+
+        await mutate<
+          CreateVerifiedMemberMutation,
+          CreateVerifiedMemberMutationVariables
+        >(CreateVerifiedMemberDocument, {
+          input: { colonyAddress, userAddress },
+        });
+      }),
+    );
+
+    await writeActionFromEvent(event, colonyAddress, {
+      type: ColonyActionType.AddVerifiedMembers,
+      initiatorAddress,
+      members: operation.members,
+    });
+
+    return;
+  }
+};

--- a/src/handlers/metadataDelta/types.ts
+++ b/src/handlers/metadataDelta/types.ts
@@ -1,10 +1,10 @@
-export enum MetadataDeltaActionType {
-  ADD_VERIFIED_MEMBERS = 'ADD_VERIFIED_MEMBERS ',
-  REMOVE_VERIFIED_MEMBERS = 'REMOVE_VERIFIED_MEMBERS ',
+export enum MetadataDeltaOperationType {
+  ADD_VERIFIED_MEMBERS = 'ADD_VERIFIED_MEMBERS',
+  REMOVE_VERIFIED_MEMBERS = 'REMOVE_VERIFIED_MEMBERS',
 }
 
 export interface AddVerifiedMembersOperation {
-  type: MetadataDeltaActionType.ADD_VERIFIED_MEMBERS;
+  type: MetadataDeltaOperationType.ADD_VERIFIED_MEMBERS;
   payload: string[];
 }
 

--- a/src/handlers/metadataDelta/types.ts
+++ b/src/handlers/metadataDelta/types.ts
@@ -1,0 +1,17 @@
+export enum OperationType {
+  ADD = 'ADD',
+  REMOVE = 'REMOVE',
+}
+
+export enum Entity {
+  VERIFIED_MEMBERS = 'verifiedMembers',
+}
+
+export interface AddVerifiedMembersOperation {
+  type: OperationType.ADD;
+  entity: Entity.VERIFIED_MEMBERS;
+  colonyAddress: string;
+  members: string[];
+}
+
+export type MetadataDeltaOperation = AddVerifiedMembersOperation;

--- a/src/handlers/metadataDelta/types.ts
+++ b/src/handlers/metadataDelta/types.ts
@@ -1,17 +1,11 @@
-export enum OperationType {
-  ADD = 'ADD',
-  REMOVE = 'REMOVE',
-}
-
-export enum Entity {
-  VERIFIED_MEMBERS = 'verifiedMembers',
+export enum MetadataDeltaActionType {
+  ADD_VERIFIED_MEMBERS = 'ADD_VERIFIED_MEMBERS ',
+  REMOVE_VERIFIED_MEMBERS = 'REMOVE_VERIFIED_MEMBERS ',
 }
 
 export interface AddVerifiedMembersOperation {
-  type: OperationType.ADD;
-  entity: Entity.VERIFIED_MEMBERS;
-  colonyAddress: string;
-  members: string[];
+  type: MetadataDeltaActionType.ADD_VERIFIED_MEMBERS;
+  payload: string[];
 }
 
 export type MetadataDeltaOperation = AddVerifiedMembersOperation;

--- a/src/handlers/metadataDelta/utils.ts
+++ b/src/handlers/metadataDelta/utils.ts
@@ -1,24 +1,39 @@
 import { verbose } from '~utils';
-import { MetadataDeltaOperation, MetadataDeltaActionType } from './types';
+import { MetadataDeltaOperation, MetadataDeltaOperationType } from './types';
 
-export const isMetadataDeltaOperation = (
+const isMetadataDeltaOperation = (
   operation: any,
 ): operation is MetadataDeltaOperation => {
   return (
     typeof operation === 'object' &&
     operation !== null &&
     operation.type !== undefined &&
-    Object.values(MetadataDeltaActionType).includes(operation.type)
+    Object.values(MetadataDeltaOperationType).includes(operation.type)
   );
 };
 
-export const parseOperation = (operationString: string): object | null => {
-  const operation = JSON.parse(operationString);
+export const parseOperation = (
+  operationString: string,
+): MetadataDeltaOperation | null => {
+  try {
+    const operation = JSON.parse(operationString);
 
-  if (typeof operation !== 'object') {
-    verbose('Operation not an object: ', operation);
+    if (typeof operation !== 'object') {
+      verbose('Operation not an object: ', operation);
+      return null;
+    }
+
+    if (!isMetadataDeltaOperation(operation)) {
+      verbose(
+        'Operation does not conform to MetadataDeltaOperation type: ',
+        operation,
+      );
+      return null;
+    }
+
+    return operation;
+  } catch (error) {
+    verbose(`String: ${operationString} cannot be parsed`, error);
     return null;
   }
-
-  return operation;
 };

--- a/src/handlers/metadataDelta/utils.ts
+++ b/src/handlers/metadataDelta/utils.ts
@@ -1,19 +1,5 @@
 import { verbose } from '~utils';
-import {
-  AddVerifiedMembersOperation,
-  Entity,
-  OperationType,
-  MetadataDeltaOperation,
-} from './types';
-
-export const isAddVerifiedMembersOperation = (
-  operation: MetadataDeltaOperation,
-): operation is AddVerifiedMembersOperation => {
-  return (
-    operation.entity === Entity.VERIFIED_MEMBERS &&
-    operation.type === OperationType.ADD
-  );
-};
+import { MetadataDeltaOperation, MetadataDeltaActionType } from './types';
 
 export const isMetadataDeltaOperation = (
   operation: any,
@@ -22,20 +8,16 @@ export const isMetadataDeltaOperation = (
     typeof operation === 'object' &&
     operation !== null &&
     operation.type !== undefined &&
-    operation.entity !== undefined &&
-    operation.colonyAddress !== undefined &&
-    typeof operation.colonyAddress === 'string' &&
-    operation.members !== undefined &&
-    Array.isArray(operation.members)
+    Object.values(MetadataDeltaActionType).includes(operation.type)
   );
 };
 
-export const parseOperation = (operationString: string): object => {
+export const parseOperation = (operationString: string): object | null => {
   const operation = JSON.parse(operationString);
 
   if (typeof operation !== 'object') {
     verbose('Operation not an object: ', operation);
-    throw new Error('Operation not an object');
+    return null;
   }
 
   return operation;

--- a/src/handlers/metadataDelta/utils.ts
+++ b/src/handlers/metadataDelta/utils.ts
@@ -1,5 +1,20 @@
 import { verbose } from '~utils';
-import { MetadataDeltaOperation, MetadataDeltaOperationType } from './types';
+import {
+  AddVerifiedMembersOperation,
+  MetadataDeltaOperation,
+  MetadataDeltaOperationType,
+} from './types';
+
+export const isAddVerifiedMembersOperation = (
+  operation: MetadataDeltaOperation,
+): operation is AddVerifiedMembersOperation => {
+  return (
+    operation.type === MetadataDeltaOperationType.ADD_VERIFIED_MEMBERS &&
+    operation.payload !== undefined &&
+    Array.isArray(operation.payload) &&
+    operation.payload.every((item) => typeof item === 'string')
+  );
+};
 
 const isMetadataDeltaOperation = (
   operation: any,

--- a/src/handlers/metadataDelta/utils.ts
+++ b/src/handlers/metadataDelta/utils.ts
@@ -1,0 +1,42 @@
+import { verbose } from '~utils';
+import {
+  AddVerifiedMembersOperation,
+  Entity,
+  OperationType,
+  MetadataDeltaOperation,
+} from './types';
+
+export const isAddVerifiedMembersOperation = (
+  operation: MetadataDeltaOperation,
+): operation is AddVerifiedMembersOperation => {
+  return (
+    operation.entity === Entity.VERIFIED_MEMBERS &&
+    operation.type === OperationType.ADD
+  );
+};
+
+export const isMetadataDeltaOperation = (
+  operation: any,
+): operation is MetadataDeltaOperation => {
+  return (
+    typeof operation === 'object' &&
+    operation !== null &&
+    operation.type !== undefined &&
+    operation.entity !== undefined &&
+    operation.colonyAddress !== undefined &&
+    typeof operation.colonyAddress === 'string' &&
+    operation.members !== undefined &&
+    Array.isArray(operation.members)
+  );
+};
+
+export const parseOperation = (operationString: string): object => {
+  const operation = JSON.parse(operationString);
+
+  if (typeof operation !== 'object') {
+    verbose('Operation not an object: ', operation);
+    throw new Error('Operation not an object');
+  }
+
+  return operation;
+};

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -101,6 +101,8 @@ export enum ContractEventsSignatures {
 
   // Reputation
   ReputationMiningCycleComplete = 'ReputationMiningCycleComplete(bytes32,uint256)',
+  // Metadata delta
+  ColonyMetadataDelta = 'ColonyMetadataDelta(address,string)',
 }
 
 /*


### PR DESCRIPTION
## Description
Added a new handler for the `ColonyMetadataDelta` event. 
The handler tries to parse the event via type guards, it currently only has support for adding verified members.
Using this approach it should be easy to implement removing of verified members.

## How to test
Easiest way is to:
1. Stop the block ingestor while running `npm run dev`, and run this branch instead.
2. spin up the CDapp on [this branch](https://github.com/JoinColony/colonyCDapp/pull/1773).
3. Choose a member that hasn't been verified yet and copy their address 
4. go to the colony dashboard home, where the temporary component for verifying members lives, paste the address and click `Verify`
![image](https://github.com/JoinColony/block-ingestor/assets/23449297/57641b70-eaa8-416c-944c-06d58df3f982)
5. Check logs to see that block-ingestor processed the transaction
6. Use GraphQL query `getVerifiedMembersByColony` to check which users are added. The user you have pasted in above should show up in the `items` array

Resolves https://github.com/JoinColony/block-ingestor/issues/160