### PR TITLE
[Verified members] Implement remove verified members motion

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -411,6 +411,8 @@ export enum ColonyActionType {
   Recovery = 'RECOVERY',
   /** An action related to removing verified members */
   RemoveVerifiedMembers = 'REMOVE_VERIFIED_MEMBERS',
+  /** An action related to removing verified members via a motion */
+  RemoveVerifiedMembersMotion = 'REMOVE_VERIFIED_MEMBERS_MOTION',
   /** An action related to setting user roles within a Colony */
   SetUserRoles = 'SET_USER_ROLES',
   /** An action related to setting user roles within a Colony via a motion */

--- a/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
+++ b/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
@@ -2,7 +2,12 @@ import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ColonyActionType } from '~graphql';
 import { ContractEvent } from '~types';
-import { isAddVerifiedMembersOperation, parseOperation, verbose } from '~utils';
+import {
+  isAddVerifiedMembersOperation,
+  isRemoveVerifiedMembersOperation,
+  parseOperation,
+  verbose,
+} from '~utils';
 import { createMotionInDB } from '../helpers';
 
 export const handleMetadataDeltaMotion = async (
@@ -27,6 +32,14 @@ export const handleMetadataDeltaMotion = async (
     if (isAddVerifiedMembersOperation(operation)) {
       await createMotionInDB(event, {
         type: ColonyActionType.AddVerifiedMembersMotion,
+        members: operation.payload,
+        gasEstimate: gasEstimate.toString(),
+      });
+    }
+
+    if (isRemoveVerifiedMembersOperation(operation)) {
+      await createMotionInDB(event, {
+        type: ColonyActionType.RemoveVerifiedMembersMotion,
         members: operation.payload,
         gasEstimate: gasEstimate.toString(),
       });


### PR DESCRIPTION
## Description
Added support for removing verified members to the `ColonyMetadataDelta` event handler.

## How to test
Easiest way is to:
1. Stop the block ingestor while running `npm run dev`, and run this branch instead.
2. spin up the CDapp on [this branch](https://github.com/JoinColony/colonyCDapp/pull/1891).
3. Enable the permissions extension
4. Choose a verified member and copy their address 
5. go to the colony dashboard home, where the temporary component for unverifying members lives, paste the address and click `Unverify via motion`
6. Fully support the motion
7. run `curl -X POST --data '{"jsonrpc":"2.0","method":"evm_increaseTime","params":[300],"id":1}' localhost:8545` to forward the time by 5 minutes
8. Finalize the motion, claim rewards, ...
9. Use GraphQL query `getVerifiedMembersByColony` to check which users are verified. The user you have pasted in above should no longer appear in the `items` array

You can also check out if it works by rejecting a motion

Resolves #163 