### PR TITLE
Fix: New Colony network version and extensions are not being picked up

### DIFF
--- a/src/eventListeners/colony.ts
+++ b/src/eventListeners/colony.ts
@@ -63,6 +63,7 @@ export const setupListenersForColonies = async (): Promise<void> => {
   });
 
   addNetworkEventListener(ContractEventsSignatures.ColonyAdded);
+  addNetworkEventListener(ContractEventsSignatures.ColonyVersionAdded);
   addNetworkEventListener(
     ContractEventsSignatures.ReputationMiningCycleComplete,
   );

--- a/src/eventListeners/extension/index.ts
+++ b/src/eventListeners/extension/index.ts
@@ -62,6 +62,7 @@ export const removeExtensionEventListeners = (
 
 export const setupListenersForExtensions = async (): Promise<void> => {
   const extensionEvents = [
+    ContractEventsSignatures.ExtensionAddedToNetwork,
     ContractEventsSignatures.ExtensionInstalled,
     ContractEventsSignatures.ExtensionUninstalled,
     ContractEventsSignatures.ExtensionDeprecated,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -43,7 +43,7 @@ export enum ContractEventsSignatures {
   ExtensionInstalled = 'ExtensionInstalled(bytes32,address,uint256)',
   ExtensionUninstalled = 'ExtensionUninstalled(bytes32,address)',
   ExtensionDeprecated = 'ExtensionDeprecated(bytes32,address,bool)',
-  ExtensionUpgraded = 'ExtensionUpgraded(indexed bytes32,indexed address,uint256)',
+  ExtensionUpgraded = 'ExtensionUpgraded(bytes32,address,uint256)',
   ExtensionInitialised = 'ExtensionInitialised()',
 
   // Actions


### PR DESCRIPTION
New colony network versions and extension versions were not being picked up by block ingestor. This was due to the event listeners not be properly initialised.

This PR ensures the event listeners are initialised correctly.

Resolves #169