### PR TITLE
Minimise number of RPC calls made while syncing

### DIFF
--- a/src/blockListener.ts
+++ b/src/blockListener.ts
@@ -1,5 +1,5 @@
 import { output, getLastBlockNumber } from '~utils';
-import { Block, EthersObserverEvents } from '~types';
+import { Block, BlockWithTransactions, EthersObserverEvents } from '~types';
 import provider from '~provider';
 import { processNextBlock } from '~blockProcessor';
 
@@ -8,7 +8,7 @@ import { processNextBlock } from '~blockProcessor';
  * or missed blocks tracking
  * Blocks are removed once processed by a call to .delete in the blockProcessor
  */
-export const blocksMap = new Map<number, Block>();
+export const blocksMap = new Map<number, Block | BlockWithTransactions>();
 let latestSeenBlockNumber = 0;
 
 export const getLatestSeenBlockNumber = (): number => latestSeenBlockNumber;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,4 @@ export const SUPPORTED_EXTENSION_IDS = [
 ];
 
 export const SIMPLE_DECISIONS_ACTION_CODE = '0x12345678';
+export const BLOCK_PAGING_SIZE = 1000;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1318,7 +1318,7 @@ export type CreateDomainInput = {
   isRoot: Scalars['Boolean'];
   nativeFundingPotId: Scalars['Int'];
   nativeId: Scalars['Int'];
-  nativeSkillId: Scalars['Int'];
+  nativeSkillId: Scalars['String'];
   reputation?: InputMaybe<Scalars['String']>;
   reputationPercentage?: InputMaybe<Scalars['String']>;
 };
@@ -1743,7 +1743,7 @@ export type Domain = {
    * Native skill ID of the Domain
    * The native skill ID is assigned to a domain from the contract on creation
    */
-  nativeSkillId: Scalars['Int'];
+  nativeSkillId: Scalars['String'];
   /** The amount of reputation in the domain */
   reputation?: Maybe<Scalars['String']>;
   /** The amount of reputation in the domain, as a percentage of the total in the colony */
@@ -2854,7 +2854,7 @@ export type ModelDomainConditionInput = {
   isRoot?: InputMaybe<ModelBooleanInput>;
   nativeFundingPotId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
-  nativeSkillId?: InputMaybe<ModelIntInput>;
+  nativeSkillId?: InputMaybe<ModelStringInput>;
   not?: InputMaybe<ModelDomainConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelDomainConditionInput>>>;
   reputation?: InputMaybe<ModelStringInput>;
@@ -2874,7 +2874,7 @@ export type ModelDomainFilterInput = {
   isRoot?: InputMaybe<ModelBooleanInput>;
   nativeFundingPotId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
-  nativeSkillId?: InputMaybe<ModelIntInput>;
+  nativeSkillId?: InputMaybe<ModelStringInput>;
   not?: InputMaybe<ModelDomainFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelDomainFilterInput>>>;
   reputation?: InputMaybe<ModelStringInput>;
@@ -3694,7 +3694,7 @@ export type ModelSubscriptionDomainFilterInput = {
   isRoot?: InputMaybe<ModelSubscriptionBooleanInput>;
   nativeFundingPotId?: InputMaybe<ModelSubscriptionIntInput>;
   nativeId?: InputMaybe<ModelSubscriptionIntInput>;
-  nativeSkillId?: InputMaybe<ModelSubscriptionIntInput>;
+  nativeSkillId?: InputMaybe<ModelSubscriptionStringInput>;
   or?: InputMaybe<Array<InputMaybe<ModelSubscriptionDomainFilterInput>>>;
   reputation?: InputMaybe<ModelSubscriptionStringInput>;
   reputationPercentage?: InputMaybe<ModelSubscriptionStringInput>;
@@ -7697,7 +7697,7 @@ export type UpdateDomainInput = {
   isRoot?: InputMaybe<Scalars['Boolean']>;
   nativeFundingPotId?: InputMaybe<Scalars['Int']>;
   nativeId?: InputMaybe<Scalars['Int']>;
-  nativeSkillId?: InputMaybe<Scalars['Int']>;
+  nativeSkillId?: InputMaybe<Scalars['String']>;
   reputation?: InputMaybe<Scalars['String']>;
   reputationPercentage?: InputMaybe<Scalars['String']>;
 };
@@ -8130,7 +8130,7 @@ export type ColonyFragment = {
     items: Array<{
       __typename?: 'Domain';
       id: string;
-      nativeSkillId: number;
+      nativeSkillId: string;
     } | null>;
   } | null;
 };
@@ -8830,7 +8830,7 @@ export type GetColonyQuery = {
       items: Array<{
         __typename?: 'Domain';
         id: string;
-        nativeSkillId: number;
+        nativeSkillId: string;
       } | null>;
     } | null;
   } | null;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -53,7 +53,7 @@ export type ChainMetadata = {
   /** The block number of the event */
   blockNumber?: Maybe<Scalars['Int']>;
   /** The chain ID of the event */
-  chainId: Scalars['Int'];
+  chainId: Scalars['String'];
   /** The log index of the event */
   logIndex?: Maybe<Scalars['Int']>;
   /** The network the event occurred on */
@@ -62,17 +62,11 @@ export type ChainMetadata = {
   transactionHash?: Maybe<Scalars['String']>;
 };
 
-/** Input data for relevant chain metadata of a Colony (if applicable) */
 export type ChainMetadataInput = {
-  /** The block number of the creation transaction */
   blockNumber?: InputMaybe<Scalars['Int']>;
-  /** The chain ID of the network */
-  chainId: Scalars['Int'];
-  /** The log index of the creation transaction */
+  chainId: Scalars['String'];
   logIndex?: InputMaybe<Scalars['Int']>;
-  /** The network the Colony is deployed on */
   network?: InputMaybe<Network>;
-  /** The transaction hash of the creation transaction */
   transactionHash?: InputMaybe<Scalars['String']>;
 };
 
@@ -2087,7 +2081,7 @@ export type GetMotionTimeoutPeriodsReturn = {
 };
 
 export type GetSafeTransactionStatusInput = {
-  chainId: Scalars['Int'];
+  chainId: Scalars['String'];
   transactionHash: Scalars['String'];
 };
 
@@ -5222,11 +5216,7 @@ export type NativeTokenStatus = {
   unlocked?: Maybe<Scalars['Boolean']>;
 };
 
-/**
- * Input data for the status of a Colony's native token
- *
- * Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later
- */
+/** Colonies can have different types of native tokens in various modes. Here we define some important properties that the dApp uses to enable or disable certain features or views. This is set when a Colony is created and can be changed later */
 export type NativeTokenStatusInput = {
   /** Whether the native token is mintable */
   mintable?: InputMaybe<Scalars['Boolean']>;
@@ -6313,14 +6303,14 @@ export type ReputationMiningCycleMetadata = {
 export type Safe = {
   __typename?: 'Safe';
   address: Scalars['String'];
-  chainId: Scalars['Int'];
+  chainId: Scalars['String'];
   moduleContractAddress: Scalars['String'];
   name: Scalars['String'];
 };
 
 export type SafeInput = {
   address: Scalars['String'];
-  chainId: Scalars['Int'];
+  chainId: Scalars['String'];
   moduleContractAddress: Scalars['String'];
   name: Scalars['String'];
 };

--- a/src/handlers/actions/createDomain.ts
+++ b/src/handlers/actions/createDomain.ts
@@ -38,7 +38,7 @@ export default async (event: ContractEvent): Promise<void> => {
         nativeId: nativeDomainId,
         isRoot: false,
         nativeFundingPotId: toNumber(fundingPotId),
-        nativeSkillId: toNumber(skillId),
+        nativeSkillId: skillId.toString(),
       },
     },
   );

--- a/src/handlers/actions/oneTxPayment.ts
+++ b/src/handlers/actions/oneTxPayment.ts
@@ -103,6 +103,14 @@ export default async (oneTxPaymentEvent: ContractEvent): Promise<void> => {
         networkInverseFee,
       );
       break;
+    default:
+      handlerV6(
+        oneTxPaymentEvent,
+        colonyAddress,
+        colonyClient,
+        networkInverseFee,
+      );
+      break;
   }
 };
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -7,7 +7,7 @@ dotenv.config();
 
 let chainId: ChainID;
 
-export const setChainId = (newChainId: number): void => {
+export const setChainId = (newChainId: ChainID): void => {
   chainId = newChainId;
 };
 export const getChainId = (): ChainID => chainId;
@@ -16,7 +16,7 @@ const provider = new providers.JsonRpcProvider(process.env.CHAIN_RPC_ENDPOINT);
 
 export const initialiseProvider = async (): Promise<void> => {
   const { chainId } = await provider.getNetwork();
-  setChainId(chainId);
+  setChainId(String(chainId));
 };
 
 export default provider;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -116,6 +116,9 @@ export enum EthersObserverEvents {
 export type ChainID = string;
 
 export type Block = Awaited<ReturnType<typeof provider.getBlock>>;
+export type BlockWithTransactions = Awaited<
+  ReturnType<typeof provider.getBlockWithTransactions>
+>;
 
 export type NetworkClients =
   | ColonyNetworkClient

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -113,7 +113,7 @@ export enum EthersObserverEvents {
   Block = 'block',
 }
 
-export type ChainID = number;
+export type ChainID = string;
 
 export type Block = Awaited<ReturnType<typeof provider.getBlock>>;
 

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -12,7 +12,7 @@ import {
   GetContractEventDocument,
   GetContractEventQuery,
   GetContractEventQueryVariables,
-  ChainMetadataInput,
+  ChainMetadata,
 } from '~graphql';
 import { blocksMap } from '~blockListener';
 
@@ -101,7 +101,7 @@ export const saveEvent = async (event: ContractEvent): Promise<void> => {
   const contractEvent: {
     id: string;
     agent: string;
-    chainMetadata: ChainMetadataInput;
+    chainMetadata: ChainMetadata;
     name: string;
     signature: string;
     target: string;

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -37,6 +37,7 @@ export const mapLogToContractEvent = async (
     let block = blocksMap.get(blockNumber);
     if (!block) {
       block = await provider.getBlock(blockNumber);
+      blocksMap.set(blockNumber, block);
     }
 
     const { hash: blockHash, timestamp } = block;

--- a/src/utils/fundsClaims.ts
+++ b/src/utils/fundsClaims.ts
@@ -37,7 +37,7 @@ export const createFundsClaim = async ({
 };
 
 export const getFundsClaimDatabaseId = (
-  chainId: number,
+  chainId: string,
   transactionHash: string,
   logIndex: number,
 ): string => `${chainId}_${transactionHash}_${logIndex}`;


### PR DESCRIPTION
## Explanation

While exploring the possibility of deploying on Arbitrum, a make-or-break issue was found with the block ingestor:

![screenshot-2024-04-01_16-13-08](https://github.com/JoinColony/block-ingestor/assets/311812/94a5545e-b26d-4172-a88b-5ae8c1ffeec2)

This is primarily because blocks on Arbitrum are 25x more frequent than they are on Gnosis (five-per-second and one-per-five-seconds, respectively). The block ingestor was able to process 100 blocks per 10-12 seconds; this is enough to keep pace and eventually sync, but if a resync was ever required (which it will be) it would have been essentially impossible.

From initial testing, this PR appears to increase the syncing performance of the block ingestor by a factor of 40 or 50, at least in the regime where most blocks do not contain transactions of interest and we have few if any colonies tracked. This makes syncing much more comfortable. There are some optimisations that will help once those assumptions are not true somewhere on Raul's machine - we could add them in this PR, or later (though today I have learned that Arbitrum blocks [will never be empty](https://www.degencode.com/p/decoding-the-arbitrum-sequencer-feed#%C2%A7l-and-l-messages), so that would only be a benefit for chains where that could be true).

## Approaches taken
The main reason for syncing being as slow as it was is due to the number of RPC requests made, and so I have done my best to remove as many as I can:

### `blockListener.js`
When started, the block ingestor would start `trackMissedBlocks`. This made a `getBlock` call for every block that was missing, until the `blocksMap` was filled with all the blocks that we were going to need. However, at this early point in the ingestion, we don't actually need that information, and we might not need it at all. So instead, we just track the most recent block we've seen (i.e. the block with the biggest number). I realise that this backfilling was non-blocking, but if there's no need to make the requests, we may as well not.

### `blockProcessor`
In `processNextBlock`, we call `getLogs` for the block. But instead, we can call `getLogs` for (as implemented here) up to 1000 blocks, and store them until we need them.

I also have resolved a TODO around `blocksMap`, and delete a block we've finished processing from it.

### `events.ts`
This is the only place we actually need the block hash and timestamp - if we are processing a block that has an event we're interested in. Now we can reasonably call `getBlock` if we need to, and store the result in case we need it later.

## Other notes

In summary, when we are syncing blocks that contain no colony events, this PR moves us from making 2 RPC requests per block to 1/1000 RPC requests per block, which results in a significant speedup. When we are synced, this seems to move to about 1/80 RPC requests per block, which is a function of the polling interval in ethers.

There's a lot of logging around the sync status that I introduced. I'm happy to remove or alter it, but it was extremely useful!

I'm not sure where to make this PR to - either `master-arbitrum` or `master`. I assume we want these improvements on `master` eventually, but for right now I don't know.

I am still a little apprehensive about the improvement seen here, and am worried I've optimised something critical out, but I've tested it locally and it seems to work, and also picked up a colony being created when we ran it through some very limited testing on the Arbitrum Sepolia test deployment.

![flex](https://github.com/JoinColony/block-ingestor/assets/311812/902b60e7-ae2d-4f35-9de5-2a18f5a59d3e)
