### PR TITLE
Fix: Duplicate incoming funds

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,3 +16,4 @@ export * from './expenditures';
 export * from './isColonyAddress';
 export * from './fundsClaims';
 export * from './metadataDelta';
+export * from './transactionHasEvent';

--- a/src/utils/transactionHasEvent.ts
+++ b/src/utils/transactionHasEvent.ts
@@ -1,0 +1,17 @@
+import { utils } from 'ethers';
+
+import provider from '~provider';
+import { ContractEventsSignatures } from '~types';
+
+/**
+ * For a given tx hash, checks whether the transaction contains a matching event
+ */
+export const transactionHasEvent = async (
+  transactionHash: string,
+  eventSignature: ContractEventsSignatures,
+): Promise<boolean> => {
+  const receipt = await provider.getTransactionReceipt(transactionHash);
+  return receipt.logs.some((log) =>
+    log.topics.includes(utils.id(eventSignature)),
+  );
+};


### PR DESCRIPTION
## Description

Incoming funds were incorrectly being duplicated. This was due to both the 'transfer' and 'expenditurePayoutClaimed' events being emitted when a payment is made from one colony to another via the OneTxPayment extension.

This PR adds a check to the 'expenditurePayoutClaimed' event to check if the event was emitted by the OneTxPayment extension and to skip creating a new claim if so (as the 'transfer' event will already do this).

## Testing

1. Send funds to a colony. (Copy the colony wallet address, switch to another colony, create a simple payment action with the colony address as the recipient)
2. Navigate to the incoming funds page.
3. The incoming funds should correctly show no duplicates.

You can also verify no duplicates are being created in the database:
```
query MyQuery {
  listColonies {
    items {
      name
      fundsClaims {
        items {
          amount
          id
        }
      }
    }
  }
}
```

## Diffs

**Changes** 🏗

* 'expenditurePayoutClaimed' event checks if the event was emitted by the OneTxPayment extension and skips creating a new claim if so (as the 'transfer' event will already do this).

Resolves #2137 

<img width="1318" alt="Screenshot 2024-04-08 at 11 08 04" src="https://github.com/JoinColony/colonyCDapp/assets/34915414/1c57e178-4ee9-4c7e-826b-c5a0ad20f4b4">
