### PR TITLE
Update default root domain colour

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1490,6 +1490,20 @@ export type CreateTransactionInput = {
   titleValues?: InputMaybe<Scalars['String']>;
 };
 
+/** Input data for creating a unique Colony within the Colony Network. Use this instead of the automatically generated `CreateColonyInput` input type */
+export type CreateUniqueColonyInput = {
+  /** Unique identifier for the Colony. This is the Colony's contract address */
+  colonyAddress: Scalars['ID'];
+  /** User id of creator to associate with further invite codes */
+  initiatorAddress: Scalars['ID'];
+  /** Unique identifier for the Colony's native token (this is its address) */
+  tokenAddress: Scalars['ID'];
+  /** The transaction hash of colony creation transaction */
+  transactionHash: Scalars['String'];
+  /** Type of the Colony (regular or MetaColony) */
+  type?: InputMaybe<ColonyType>;
+};
+
 /** Input data for creating a unique user within the Colony Network Use this instead of the automatically generated `CreateUserInput` input type */
 export type CreateUniqueUserInput = {
   /** Unique identifier for the user. This is the user's wallet address */
@@ -1772,6 +1786,8 @@ export enum DomainColor {
   PurpleGrey = 'PURPLE_GREY',
   /** A red color */
   Red = 'RED',
+  /** The default root domain color */
+  Root = 'ROOT',
   /** A yellow color */
   Yellow = 'YELLOW',
 }
@@ -4353,6 +4369,8 @@ export type Mutation = {
   createStreamingPaymentMetadata?: Maybe<StreamingPaymentMetadata>;
   createToken?: Maybe<Token>;
   createTransaction?: Maybe<Transaction>;
+  /** Create a unique Colony within the Colony Network. Use this instead of the automatically generated `createColony` mutation */
+  createUniqueColony?: Maybe<Colony>;
   /** Create a unique user within the Colony Network. Use this instead of the automatically generated `createUser` mutation */
   createUniqueUser?: Maybe<User>;
   createUser?: Maybe<User>;
@@ -4660,6 +4678,11 @@ export type MutationCreateTokenArgs = {
 export type MutationCreateTransactionArgs = {
   condition?: InputMaybe<ModelTransactionConditionInput>;
   input: CreateTransactionInput;
+};
+
+/** Root mutation type */
+export type MutationCreateUniqueColonyArgs = {
+  input?: InputMaybe<CreateUniqueColonyInput>;
 };
 
 /** Root mutation type */

--- a/src/handlers/colonies/helpers/createUniqueColony.ts
+++ b/src/handlers/colonies/helpers/createUniqueColony.ts
@@ -303,7 +303,7 @@ export const createUniqueColony = async ({
   >(CreateDomainMetadataDocument, {
     input: {
       id: `${checksummedAddress}_${Id.RootDomain}`,
-      color: DomainColor.LightPink,
+      color: DomainColor.Root,
       name: 'General',
       description: '',
     },


### PR DESCRIPTION
## Changes

- Update of the generated code following this PR: https://github.com/JoinColony/colonyCDapp/pull/2269
- Change the default colour of the root domain on colony creation


## Testing

- First, ensure that the CDapp PR is merged, or that you're running it all locally with both branches.
- Create a new colony
- Check that the colour of the General domain is blue-400

