### PR TITLE
Optimize Block Processing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ AWS_APPSYNC_KEY=da2-fakeApiId123456
 NODE_ENV=development
 
 BLOCK_TIME=5 # in seconds
+
+# Number of blocks to process in a single batch
+# Helps greatly with fast networks (ie: Arbitrum)
+BLOCK_PAGING_SIZE=1000

--- a/src/blockListener.ts
+++ b/src/blockListener.ts
@@ -1,5 +1,5 @@
 import { output, getLastBlockNumber } from '~utils';
-import { Block, EthersObserverEvents } from '~types';
+import { Block, BlockWithTransactions, EthersObserverEvents } from '~types';
 import provider from '~provider';
 import { processNextBlock } from '~blockProcessor';
 
@@ -8,7 +8,7 @@ import { processNextBlock } from '~blockProcessor';
  * or missed blocks tracking
  * Blocks are removed once processed by a call to .delete in the blockProcessor
  */
-export const blocksMap = new Map<number, Block>();
+export const blocksMap = new Map<number, Block | BlockWithTransactions>();
 let latestSeenBlockNumber = 0;
 
 export const getLatestSeenBlockNumber = (): number => latestSeenBlockNumber;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,3 +12,4 @@ export const SUPPORTED_EXTENSION_IDS = [
 ];
 
 export const SIMPLE_DECISIONS_ACTION_CODE = '0x12345678';
+export const BLOCK_PAGING_SIZE = 1000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,4 +12,6 @@ export const SUPPORTED_EXTENSION_IDS = [
 ];
 
 export const SIMPLE_DECISIONS_ACTION_CODE = '0x12345678';
-export const BLOCK_PAGING_SIZE = 1000;
+export const BLOCK_PAGING_SIZE = process.env.BLOCK_PAGING_SIZE
+  ? parseInt(process.env.BLOCK_PAGING_SIZE, 10)
+  : 1000;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -117,6 +117,9 @@ export enum EthersObserverEvents {
 export type ChainID = string;
 
 export type Block = Awaited<ReturnType<typeof provider.getBlock>>;
+export type BlockWithTransactions = Awaited<
+  ReturnType<typeof provider.getBlockWithTransactions>
+>;
 
 export type NetworkClients =
   | ColonyNetworkClient

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -37,6 +37,7 @@ export const mapLogToContractEvent = async (
     let block = blocksMap.get(blockNumber);
     if (!block) {
       block = await provider.getBlock(blockNumber);
+      blocksMap.set(blockNumber, block);
     }
 
     const { hash: blockHash, timestamp } = block;


### PR DESCRIPTION
> ## Disclamer
>
> This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 
>
> We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.
>
> This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

Most, well... rather all work in this PR has been actually done by @area so all kudos go to him.

This change comes as a response to our Arbitrum deployment and it's way faster block speeds _(`250ms` / block)_, which was way more faster than we were equipped to handle _(gnosis has a `5sec` / block interval)_.

To improve the block ingestor to handle these new speeds, Alex made block processing in batches _(configurable via a ENV variable)_, and just handling the relevant logs from that batch. This comes a improvement over old version of processing each block individually, as well as fetching logs for each block, even if they were not relevant to the ingestor.

## Testing

Testing this is kinda tricky since you won't be able to actually get close to those kind of speeds locally, but you can check the output of the ingestor and see the batching in action. You should see a lot of blocks being added to the queue and one batch to process them. Every `BLOCK_PAGING_SIZE` block you should also see a message telling you how long it took to process that batch of blocks

