### PR TITLE
Fix Colony Creation (on networks with faster block time)

### DIFF
--- a/src/handlers/colonies/colonyAdded.ts
+++ b/src/handlers/colonies/colonyAdded.ts
@@ -40,6 +40,9 @@ export default async (event: ContractEvent): Promise<void> => {
    * If colony metadata doesn't exist, log it and do not create anything in the DB
    * In dev, this will be the case for Metacolony
    */
+
+  console.log({ colonyMetadata });
+
   if (!colonyMetadata?.getColonyMetadata) {
     output(`Could not find metadata for colony ${colonyAddress}. Skipping...`);
     return;

--- a/src/handlers/colonies/colonyAdded.ts
+++ b/src/handlers/colonies/colonyAdded.ts
@@ -26,22 +26,21 @@ export default async (event: ContractEvent): Promise<void> => {
 
   /*
    * Determine if the colony metadata was created from the client side
-   * by trying to fetch/refetch it up to a number of 3 blocks in prod or 10 in dev
+   * by trying to fetch/refetch it up to a certain number of blocks
    */
-  const colonyMetadata = await tryFetchGraphqlQuery(
-    GetColonyMetadataDocument,
-    {
+  let colonyMetadata: Record<string, Record<string, unknown>> = {};
+  try {
+    colonyMetadata = await tryFetchGraphqlQuery(GetColonyMetadataDocument, {
       id: `etherealcolonymetadata-${transactionHash}`,
-    },
-    process.env.NODE_ENV !== 'production' ? 10 : undefined,
-  );
+    });
+  } catch (error) {
+    // Most likely we couldn't find metadata for this particular colony
+  }
 
   /**
    * If colony metadata doesn't exist, log it and do not create anything in the DB
    * In dev, this will be the case for Metacolony
    */
-
-  console.log({ colonyMetadata });
 
   if (!colonyMetadata?.getColonyMetadata) {
     output(`Could not find metadata for colony ${colonyAddress}. Skipping...`);

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,5 +1,5 @@
 import dotenv from 'dotenv';
-import { DocumentNode } from 'graphql';
+import { DocumentNode, Kind, isExecutableDefinitionNode } from 'graphql';
 
 import { query } from '~amplifyClient';
 
@@ -11,9 +11,11 @@ export const delay = async (timeout: number): Promise<void> => {
   });
 };
 
-export const tryFetchGraphqlQuery = async (
+export const tryFetchGraphqlQuery = async <
+  TVariables extends Record<string, unknown> = {},
+>(
   queryString: DocumentNode,
-  variables?: Record<string, any>,
+  variables?: TVariables,
   maxRetries: number = 3,
   blockTime: number = process.env.BLOCK_TIME
     ? parseInt(process.env.BLOCK_TIME, 10) * 1000
@@ -21,25 +23,21 @@ export const tryFetchGraphqlQuery = async (
 ): Promise<any> => {
   let currentTry = 0;
 
-  console.log({ currentTry, maxRetries, blockTime });
-
   while (true) {
-    const result = await query(queryString, variables);
+    const result = await query<Record<string, unknown>, TVariables>(
+      queryString,
+      variables,
+    );
 
     /*
      * @NOTE That this limits to only fetching one operation at a time
      */
 
-    console.log({ result });
-    console.log(queryString.definitions[0]);
+    const queryFieldName = extractQueryFieldName(queryString);
 
-    // result.data.getColonyMetadata = null
-    // @ts-expect-error
-    if (result?.data?.getColonyMetadata) {
+    if (result?.data?.[queryFieldName]) {
       return result.data;
     }
-
-    console.log({ currentTry });
 
     if (currentTry < maxRetries) {
       await delay(blockTime);
@@ -49,4 +47,19 @@ export const tryFetchGraphqlQuery = async (
       throw new Error('Could not fetch graphql data in time');
     }
   }
+};
+
+const extractQueryFieldName = (queryString: DocumentNode): string => {
+  const definitionNode = queryString.definitions[0];
+
+  if (!isExecutableDefinitionNode(definitionNode)) {
+    throw new Error('Could not extract query field name');
+  }
+
+  const selectionNode = definitionNode.selectionSet.selections[0];
+  if (selectionNode.kind !== Kind.FIELD) {
+    throw new Error('Could not extract query field name');
+  }
+
+  return selectionNode.name.value;
 };

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -20,18 +20,30 @@ export const tryFetchGraphqlQuery = async (
     : 5000,
 ): Promise<any> => {
   let currentTry = 0;
+
+  console.log({ currentTry, maxRetries, blockTime });
+
   while (true) {
     const result = await query(queryString, variables);
 
     /*
      * @NOTE That this limits to only fetching one operation at a time
      */
-    if (result?.data) {
+
+    console.log({ result });
+    console.log(queryString.definitions[0]);
+
+    // result.data.getColonyMetadata = null
+    // @ts-expect-error
+    if (result?.data?.getColonyMetadata) {
       return result.data;
     }
 
+    console.log({ currentTry });
+
     if (currentTry < maxRetries) {
       await delay(blockTime);
+      console.log('this should delay');
       currentTry += 1;
     } else {
       throw new Error('Could not fetch graphql data in time');


### PR DESCRIPTION
> ## Disclamer
>
> This PR is part of the set that will be opened by me to (re)introduce all the changes made to support the Arbitrum deployment, from the `master-arbitrum` branch back into `master` so that the two branches can be _(more or less)_ identical 
>
> We need to run two branches, since AWS enforces one deployment per branch, meaning we can't run both the `Gnosis` and `Arbitrum` deployment from the same branch.
>
> This will get cleaned up, once we get to Multichain and we will be back to only supporting one main deployment _(which itself will support multiple networks, whatever form this might take)_

## Current PR Details

This is actually just a fix of the `tryFetchGraphqlQuery` util _(work done by @jakubcolony)_ which is used to "wait" until a colony's metadata exist, then proceed with the creation. This piece of logic was used to separate chain created colonies from UI created colonies.

However, this util was actually broken, but due to the slower speeds of Gnosis, it was never revealed. Only on Arbitrum, with it's faster block times, did this problem actually surface.

## Testing

Testing this is kinda tricky since you won't be able to actually get close to those kind of speeds locally, but just creating a colony should do the trick. If your colony gets created, then you're all good.

