### PR TITLE
Keep incoming funds in db after claiming

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -512,6 +512,8 @@ export type ColonyChainFundsClaim = {
   createdAtBlock: Scalars['Int'];
   /** Unique identifier for the Colony Chain Funds Claim */
   id: Scalars['ID'];
+  /** Boolean to indicate whether the claim has been claimed or not */
+  isClaimed?: Maybe<Scalars['Boolean']>;
   /** Timestamp when the Chain Funds Claim was last updated */
   updatedAt: Scalars['AWSDateTime'];
 };
@@ -521,6 +523,7 @@ export type ColonyChainFundsClaimInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   createdAtBlock: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
+  isClaimed?: InputMaybe<Scalars['Boolean']>;
   updatedAt?: InputMaybe<Scalars['AWSDateTime']>;
 };
 
@@ -636,6 +639,8 @@ export type ColonyFundsClaim = {
   createdAtBlock: Scalars['Int'];
   /** Unique identifier for the Colony Funds Claim */
   id: Scalars['ID'];
+  /** Boolean to indicate whether the claim has been claimed or not */
+  isClaimed?: Maybe<Scalars['Boolean']>;
   /** Token associated with the Colony Funds Claim */
   token: Token;
   updatedAt: Scalars['AWSDateTime'];
@@ -1208,6 +1213,7 @@ export type CreateColonyFundsClaimInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   createdAtBlock: Scalars['Int'];
   id?: InputMaybe<Scalars['ID']>;
+  isClaimed?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type CreateColonyHistoricRoleInput = {
@@ -2536,6 +2542,7 @@ export type ModelColonyFundsClaimConditionInput = {
   colonyFundsClaimsId?: InputMaybe<ModelIdInput>;
   createdAt?: InputMaybe<ModelStringInput>;
   createdAtBlock?: InputMaybe<ModelIntInput>;
+  isClaimed?: InputMaybe<ModelBooleanInput>;
   not?: InputMaybe<ModelColonyFundsClaimConditionInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyFundsClaimConditionInput>>>;
 };
@@ -2554,6 +2561,7 @@ export type ModelColonyFundsClaimFilterInput = {
   createdAt?: InputMaybe<ModelStringInput>;
   createdAtBlock?: InputMaybe<ModelIntInput>;
   id?: InputMaybe<ModelIdInput>;
+  isClaimed?: InputMaybe<ModelBooleanInput>;
   not?: InputMaybe<ModelColonyFundsClaimFilterInput>;
   or?: InputMaybe<Array<InputMaybe<ModelColonyFundsClaimFilterInput>>>;
 };
@@ -3607,6 +3615,7 @@ export type ModelSubscriptionColonyFundsClaimFilterInput = {
   createdAt?: InputMaybe<ModelSubscriptionStringInput>;
   createdAtBlock?: InputMaybe<ModelSubscriptionIntInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
+  isClaimed?: InputMaybe<ModelSubscriptionBooleanInput>;
   or?: InputMaybe<
     Array<InputMaybe<ModelSubscriptionColonyFundsClaimFilterInput>>
   >;
@@ -5578,6 +5587,7 @@ export type Query = {
   listUsers?: Maybe<ModelUserConnection>;
   searchColonyActions?: Maybe<SearchableColonyActionConnection>;
   searchColonyContributors?: Maybe<SearchableColonyContributorConnection>;
+  searchColonyFundsClaims?: Maybe<SearchableColonyFundsClaimConnection>;
 };
 
 /** Root query type */
@@ -6399,6 +6409,18 @@ export type QuerySearchColonyContributorsArgs = {
   sort?: InputMaybe<Array<InputMaybe<SearchableColonyContributorSortInput>>>;
 };
 
+/** Root query type */
+export type QuerySearchColonyFundsClaimsArgs = {
+  aggregates?: InputMaybe<
+    Array<InputMaybe<SearchableColonyFundsClaimAggregationInput>>
+  >;
+  filter?: InputMaybe<SearchableColonyFundsClaimFilterInput>;
+  from?: InputMaybe<Scalars['Int']>;
+  limit?: InputMaybe<Scalars['Int']>;
+  nextToken?: InputMaybe<Scalars['String']>;
+  sort?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimSortInput>>>;
+};
+
 export type RemoveMemberFromColonyWhitelistInput = {
   /** The colony address */
   colonyAddress: Scalars['ID'];
@@ -6697,6 +6719,61 @@ export enum SearchableColonyContributorSortableFields {
   Id = 'id',
   IsVerified = 'isVerified',
   IsWatching = 'isWatching',
+  UpdatedAt = 'updatedAt',
+}
+
+export enum SearchableColonyFundsClaimAggregateField {
+  Amount = 'amount',
+  ColonyFundsClaimTokenId = 'colonyFundsClaimTokenId',
+  ColonyFundsClaimsId = 'colonyFundsClaimsId',
+  CreatedAt = 'createdAt',
+  CreatedAtBlock = 'createdAtBlock',
+  Id = 'id',
+  IsClaimed = 'isClaimed',
+  UpdatedAt = 'updatedAt',
+}
+
+export type SearchableColonyFundsClaimAggregationInput = {
+  field: SearchableColonyFundsClaimAggregateField;
+  name: Scalars['String'];
+  type: SearchableAggregateType;
+};
+
+export type SearchableColonyFundsClaimConnection = {
+  __typename?: 'SearchableColonyFundsClaimConnection';
+  aggregateItems: Array<Maybe<SearchableAggregateResult>>;
+  items: Array<Maybe<ColonyFundsClaim>>;
+  nextToken?: Maybe<Scalars['String']>;
+  total?: Maybe<Scalars['Int']>;
+};
+
+export type SearchableColonyFundsClaimFilterInput = {
+  amount?: InputMaybe<SearchableStringFilterInput>;
+  and?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimFilterInput>>>;
+  colonyFundsClaimTokenId?: InputMaybe<SearchableIdFilterInput>;
+  colonyFundsClaimsId?: InputMaybe<SearchableIdFilterInput>;
+  createdAt?: InputMaybe<SearchableStringFilterInput>;
+  createdAtBlock?: InputMaybe<SearchableIntFilterInput>;
+  id?: InputMaybe<SearchableIdFilterInput>;
+  isClaimed?: InputMaybe<SearchableBooleanFilterInput>;
+  not?: InputMaybe<SearchableColonyFundsClaimFilterInput>;
+  or?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimFilterInput>>>;
+  updatedAt?: InputMaybe<SearchableStringFilterInput>;
+};
+
+export type SearchableColonyFundsClaimSortInput = {
+  direction?: InputMaybe<SearchableSortDirection>;
+  field?: InputMaybe<SearchableColonyFundsClaimSortableFields>;
+};
+
+export enum SearchableColonyFundsClaimSortableFields {
+  Amount = 'amount',
+  ColonyFundsClaimTokenId = 'colonyFundsClaimTokenId',
+  ColonyFundsClaimsId = 'colonyFundsClaimsId',
+  CreatedAt = 'createdAt',
+  CreatedAtBlock = 'createdAtBlock',
+  Id = 'id',
+  IsClaimed = 'isClaimed',
   UpdatedAt = 'updatedAt',
 }
 
@@ -7724,6 +7801,7 @@ export type UpdateColonyFundsClaimInput = {
   createdAt?: InputMaybe<Scalars['AWSDateTime']>;
   createdAtBlock?: InputMaybe<Scalars['Int']>;
   id: Scalars['ID'];
+  isClaimed?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type UpdateColonyHistoricRoleInput = {
@@ -8836,6 +8914,19 @@ export type CreateColonyFundsClaimMutationVariables = Exact<{
 export type CreateColonyFundsClaimMutation = {
   __typename?: 'Mutation';
   createColonyFundsClaim?: {
+    __typename?: 'ColonyFundsClaim';
+    id: string;
+  } | null;
+};
+
+export type UpdateColonyFundsClaimMutationVariables = Exact<{
+  input: UpdateColonyFundsClaimInput;
+  condition?: InputMaybe<ModelColonyFundsClaimConditionInput>;
+}>;
+
+export type UpdateColonyFundsClaimMutation = {
+  __typename?: 'Mutation';
+  updateColonyFundsClaim?: {
     __typename?: 'ColonyFundsClaim';
     id: string;
   } | null;
@@ -10298,6 +10389,16 @@ export const CreateColonyFundsClaimDocument = gql`
     }
   }
 `;
+export const UpdateColonyFundsClaimDocument = gql`
+  mutation UpdateColonyFundsClaim(
+    $input: UpdateColonyFundsClaimInput!
+    $condition: ModelColonyFundsClaimConditionInput
+  ) {
+    updateColonyFundsClaim(input: $input, condition: $condition) {
+      id
+    }
+  }
+`;
 export const DeleteColonyFundsClaimDocument = gql`
   mutation DeleteColonyFundsClaim(
     $input: DeleteColonyFundsClaimInput!
@@ -10745,6 +10846,7 @@ export const GetColonyUnclaimedFundsDocument = gql`
         colonyFundsClaimsId: { eq: $colonyAddress }
         colonyFundsClaimTokenId: { eq: $tokenAddress }
         createdAtBlock: { le: $upToBlock }
+        isClaimed: { ne: true }
       }
     ) {
       items {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -5587,7 +5587,6 @@ export type Query = {
   listUsers?: Maybe<ModelUserConnection>;
   searchColonyActions?: Maybe<SearchableColonyActionConnection>;
   searchColonyContributors?: Maybe<SearchableColonyContributorConnection>;
-  searchColonyFundsClaims?: Maybe<SearchableColonyFundsClaimConnection>;
 };
 
 /** Root query type */
@@ -6409,18 +6408,6 @@ export type QuerySearchColonyContributorsArgs = {
   sort?: InputMaybe<Array<InputMaybe<SearchableColonyContributorSortInput>>>;
 };
 
-/** Root query type */
-export type QuerySearchColonyFundsClaimsArgs = {
-  aggregates?: InputMaybe<
-    Array<InputMaybe<SearchableColonyFundsClaimAggregationInput>>
-  >;
-  filter?: InputMaybe<SearchableColonyFundsClaimFilterInput>;
-  from?: InputMaybe<Scalars['Int']>;
-  limit?: InputMaybe<Scalars['Int']>;
-  nextToken?: InputMaybe<Scalars['String']>;
-  sort?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimSortInput>>>;
-};
-
 export type RemoveMemberFromColonyWhitelistInput = {
   /** The colony address */
   colonyAddress: Scalars['ID'];
@@ -6719,61 +6706,6 @@ export enum SearchableColonyContributorSortableFields {
   Id = 'id',
   IsVerified = 'isVerified',
   IsWatching = 'isWatching',
-  UpdatedAt = 'updatedAt',
-}
-
-export enum SearchableColonyFundsClaimAggregateField {
-  Amount = 'amount',
-  ColonyFundsClaimTokenId = 'colonyFundsClaimTokenId',
-  ColonyFundsClaimsId = 'colonyFundsClaimsId',
-  CreatedAt = 'createdAt',
-  CreatedAtBlock = 'createdAtBlock',
-  Id = 'id',
-  IsClaimed = 'isClaimed',
-  UpdatedAt = 'updatedAt',
-}
-
-export type SearchableColonyFundsClaimAggregationInput = {
-  field: SearchableColonyFundsClaimAggregateField;
-  name: Scalars['String'];
-  type: SearchableAggregateType;
-};
-
-export type SearchableColonyFundsClaimConnection = {
-  __typename?: 'SearchableColonyFundsClaimConnection';
-  aggregateItems: Array<Maybe<SearchableAggregateResult>>;
-  items: Array<Maybe<ColonyFundsClaim>>;
-  nextToken?: Maybe<Scalars['String']>;
-  total?: Maybe<Scalars['Int']>;
-};
-
-export type SearchableColonyFundsClaimFilterInput = {
-  amount?: InputMaybe<SearchableStringFilterInput>;
-  and?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimFilterInput>>>;
-  colonyFundsClaimTokenId?: InputMaybe<SearchableIdFilterInput>;
-  colonyFundsClaimsId?: InputMaybe<SearchableIdFilterInput>;
-  createdAt?: InputMaybe<SearchableStringFilterInput>;
-  createdAtBlock?: InputMaybe<SearchableIntFilterInput>;
-  id?: InputMaybe<SearchableIdFilterInput>;
-  isClaimed?: InputMaybe<SearchableBooleanFilterInput>;
-  not?: InputMaybe<SearchableColonyFundsClaimFilterInput>;
-  or?: InputMaybe<Array<InputMaybe<SearchableColonyFundsClaimFilterInput>>>;
-  updatedAt?: InputMaybe<SearchableStringFilterInput>;
-};
-
-export type SearchableColonyFundsClaimSortInput = {
-  direction?: InputMaybe<SearchableSortDirection>;
-  field?: InputMaybe<SearchableColonyFundsClaimSortableFields>;
-};
-
-export enum SearchableColonyFundsClaimSortableFields {
-  Amount = 'amount',
-  ColonyFundsClaimTokenId = 'colonyFundsClaimTokenId',
-  ColonyFundsClaimsId = 'colonyFundsClaimsId',
-  CreatedAt = 'createdAt',
-  CreatedAtBlock = 'createdAtBlock',
-  Id = 'id',
-  IsClaimed = 'isClaimed',
   UpdatedAt = 'updatedAt',
 }
 

--- a/src/graphql/mutations/funds.graphql
+++ b/src/graphql/mutations/funds.graphql
@@ -7,6 +7,15 @@ mutation CreateColonyFundsClaim(
   }
 }
 
+mutation UpdateColonyFundsClaim(
+  $input: UpdateColonyFundsClaimInput!
+  $condition: ModelColonyFundsClaimConditionInput
+) {
+  updateColonyFundsClaim(input: $input, condition: $condition) {
+    id
+  }
+}
+
 mutation DeleteColonyFundsClaim(
   $input: DeleteColonyFundsClaimInput!
   $condition: ModelColonyFundsClaimConditionInput

--- a/src/graphql/queries/funds.graphql
+++ b/src/graphql/queries/funds.graphql
@@ -8,6 +8,7 @@ query GetColonyUnclaimedFunds(
       colonyFundsClaimsId: { eq: $colonyAddress }
       colonyFundsClaimTokenId: { eq: $tokenAddress }
       createdAtBlock: { le: $upToBlock }
+      isClaimed: { ne: true }
     }
   ) {
     items {

--- a/src/handlers/colonies/colonyFundsClaimed.ts
+++ b/src/handlers/colonies/colonyFundsClaimed.ts
@@ -4,9 +4,9 @@ import { mutate, query } from '~amplifyClient';
 import { ContractEvent } from '~types';
 import { output, saveEvent, notNull } from '~utils';
 import {
-  DeleteColonyFundsClaimDocument,
-  DeleteColonyFundsClaimMutation,
-  DeleteColonyFundsClaimMutationVariables,
+  UpdateColonyFundsClaimDocument,
+  UpdateColonyFundsClaimMutation,
+  UpdateColonyFundsClaimMutationVariables,
   GetColonyUnclaimedFundsDocument,
   GetColonyUnclaimedFundsQuery,
   GetColonyUnclaimedFundsQueryVariables,
@@ -53,14 +53,14 @@ export default async (event: ContractEvent): Promise<void> => {
      */
     if (colonyHasUnclaimedFunds) {
       await Promise.all(
-        unclaimedFunds
-          .filter(notNull)
-          .map(({ id }) =>
-            mutate<
-              DeleteColonyFundsClaimMutation,
-              DeleteColonyFundsClaimMutationVariables
-            >(DeleteColonyFundsClaimDocument, { input: { id } }),
-          ),
+        unclaimedFunds.filter(notNull).map(({ id }) =>
+          mutate<
+            UpdateColonyFundsClaimMutation,
+            UpdateColonyFundsClaimMutationVariables
+          >(UpdateColonyFundsClaimDocument, {
+            input: { id, isClaimed: true },
+          }),
+        ),
       );
     }
   } else {

--- a/src/utils/fundsClaims.ts
+++ b/src/utils/fundsClaims.ts
@@ -31,6 +31,7 @@ export const createFundsClaim = async ({
       colonyFundsClaimsId: colonyAddress,
       colonyFundsClaimTokenId: tokenAddress,
       createdAtBlock: blockNumber,
+      isClaimed: false,
       amount,
     },
   });


### PR DESCRIPTION
Update the colonyFundsClaimed handler to keep incoming funds in the database once they are claimed.

To test, run your cdapp with this commit as the commit hash for your block-ingestor image.
Create an incoming fund in a colony, and claim it.
It should still exist in the db, but with `isClaimed` set to true.