### PR TITLE
Fix: ingestor possibly skipping some events

### DIFF
--- a/src/eventListeners/extension/index.ts
+++ b/src/eventListeners/extension/index.ts
@@ -86,11 +86,11 @@ export const setupListenersForExtensions = async (): Promise<void> => {
     ),
   );
 
-  setupListenerForOneTxPaymentExtensions();
-  setupListenersForVotingReputationExtensions();
-  setupListenersForStakedExpenditureExtensions();
-  setupListenersForStagedExpenditureExtensions();
-  setupListenersForStreamingPaymentsExtensions();
+  await setupListenerForOneTxPaymentExtensions();
+  await setupListenersForVotingReputationExtensions();
+  await setupListenersForStakedExpenditureExtensions();
+  await setupListenersForStagedExpenditureExtensions();
+  await setupListenersForStreamingPaymentsExtensions();
 };
 
 export const fetchExistingExtensions = async (


### PR DESCRIPTION
It looks like by mistake, we never awaited promises inside `setupListenersForExtensions` which meant the event processing would potentially start before the listeners were in place.

## Steps to reproduce the original issue
I noticed this when testing https://github.com/JoinColony/colonyCDapp/pull/2490.

- Create a motion
- Disable block-ingestor (it will need to be run outside Docker at that point)
- Stake/oppose the motion
- Enable block-ingestor

In `master`, the stake event would not get picked up by ingestor and get lost without updating the motion. This fix should rectify that issue.