### PR TITLE
Feat: handle the StreamingPayments contract's ClaimWaived event emission

### DIFF
--- a/src/eventProcessor.ts
+++ b/src/eventProcessor.ts
@@ -57,6 +57,7 @@ import {
   handleStakeFractionSet,
   handleStreamingPaymentEndTimeSet,
   handleStreamingPaymentClaimed,
+  handleStreamingPaymentClaimWaived,
 } from './handlers';
 
 dotenv.config();
@@ -346,6 +347,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
     case ContractEventsSignatures.EndTimeSet: {
       await handleStreamingPaymentEndTimeSet(event);
+      return;
+    }
+
+    case ContractEventsSignatures.ClaimWaived: {
+      await handleStreamingPaymentClaimWaived(event);
       return;
     }
 

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -382,6 +382,8 @@ export enum ColonyActionType {
   /** An action related to adding verified members */
   AddVerifiedMembers = 'ADD_VERIFIED_MEMBERS',
   AddVerifiedMembersMotion = 'ADD_VERIFIED_MEMBERS_MOTION',
+  /** An action related to cancelling and waiving a streaming payment */
+  CancelAndWaiveStreamingPayment = 'CANCEL_AND_WAIVE_STREAMING_PAYMENT',
   /** An action related to canceling an expenditure */
   CancelExpenditure = 'CANCEL_EXPENDITURE',
   /** An action related to a motion to cancel an expenditure */
@@ -1493,6 +1495,7 @@ export type CreateStreamingPaymentInput = {
   id?: InputMaybe<Scalars['ID']>;
   interval: Scalars['String'];
   isCancelled?: InputMaybe<Scalars['Boolean']>;
+  isWaived?: InputMaybe<Scalars['Boolean']>;
   nativeDomainId: Scalars['Int'];
   nativeId: Scalars['Int'];
   recipientAddress: Scalars['String'];
@@ -3415,6 +3418,7 @@ export type ModelStreamingPaymentConditionInput = {
   endTime?: InputMaybe<ModelIntInput>;
   interval?: InputMaybe<ModelStringInput>;
   isCancelled?: InputMaybe<ModelBooleanInput>;
+  isWaived?: InputMaybe<ModelBooleanInput>;
   nativeDomainId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelStreamingPaymentConditionInput>;
@@ -3443,6 +3447,7 @@ export type ModelStreamingPaymentFilterInput = {
   id?: InputMaybe<ModelIdInput>;
   interval?: InputMaybe<ModelStringInput>;
   isCancelled?: InputMaybe<ModelBooleanInput>;
+  isWaived?: InputMaybe<ModelBooleanInput>;
   nativeDomainId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelStreamingPaymentFilterInput>;
@@ -4014,6 +4019,7 @@ export type ModelSubscriptionStreamingPaymentFilterInput = {
   id?: InputMaybe<ModelSubscriptionIdInput>;
   interval?: InputMaybe<ModelSubscriptionStringInput>;
   isCancelled?: InputMaybe<ModelSubscriptionBooleanInput>;
+  isWaived?: InputMaybe<ModelSubscriptionBooleanInput>;
   nativeDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   nativeId?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<
@@ -6895,6 +6901,8 @@ export type StreamingPayment = {
   interval: Scalars['String'];
   /** Is the stream cancelled? */
   isCancelled?: Maybe<Scalars['Boolean']>;
+  /** Is the stream waived? */
+  isWaived?: Maybe<Scalars['Boolean']>;
   metadata?: Maybe<StreamingPaymentMetadata>;
   nativeDomainId: Scalars['Int'];
   nativeId: Scalars['Int'];
@@ -8109,12 +8117,12 @@ export type UpdateStreamingPaymentInput = {
   id: Scalars['ID'];
   interval?: InputMaybe<Scalars['String']>;
   isCancelled?: InputMaybe<Scalars['Boolean']>;
+  isWaived?: InputMaybe<Scalars['Boolean']>;
   nativeDomainId?: InputMaybe<Scalars['Int']>;
   nativeId?: InputMaybe<Scalars['Int']>;
   recipientAddress?: InputMaybe<Scalars['String']>;
   startTime?: InputMaybe<Scalars['AWSTimestamp']>;
   tokenAddress?: InputMaybe<Scalars['String']>;
-  isWaived?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type UpdateStreamingPaymentMetadataInput = {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8114,6 +8114,7 @@ export type UpdateStreamingPaymentInput = {
   recipientAddress?: InputMaybe<Scalars['String']>;
   startTime?: InputMaybe<Scalars['AWSTimestamp']>;
   tokenAddress?: InputMaybe<Scalars['String']>;
+  isWaived?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type UpdateStreamingPaymentMetadataInput = {

--- a/src/handlers/expenditures/index.ts
+++ b/src/handlers/expenditures/index.ts
@@ -20,3 +20,4 @@ export { default as handlePaymentTokenUpdated } from './paymentTokenUpdated';
 export { default as handleExpenditureStateChanged } from './expenditureStateChanged';
 export { default as handleStakeFractionSet } from './stakeFractionSet';
 export { default as handleStreamingPaymentClaimed } from './streamingPaymentClaimed';
+export { default as handleStreamingPaymentClaimWaived } from './streamingPaymentClaimWaived';

--- a/src/handlers/expenditures/streamingPaymentClaimWaived.ts
+++ b/src/handlers/expenditures/streamingPaymentClaimWaived.ts
@@ -1,0 +1,35 @@
+import { mutate } from '~amplifyClient';
+import {
+  UpdateStreamingPaymentDocument,
+  UpdateStreamingPaymentMutation,
+  UpdateStreamingPaymentMutationVariables,
+} from '~graphql';
+import { ContractEvent } from '~types';
+import { getExpenditureDatabaseId, toNumber, verbose } from '~utils';
+
+export default async (event: ContractEvent): Promise<void> => {
+  console.log('ROMEO IM IN!');
+
+  const { colonyAddress } = event;
+  const { streamingPaymentId } = event.args;
+  const convertedNativeId = toNumber(streamingPaymentId);
+
+  if (!colonyAddress) {
+    return;
+  }
+
+  const databaseId = getExpenditureDatabaseId(colonyAddress, convertedNativeId);
+
+  await mutate<
+    UpdateStreamingPaymentMutation,
+    UpdateStreamingPaymentMutationVariables
+  >(UpdateStreamingPaymentDocument, {
+    input: {
+      id: databaseId,
+      isWaived: true,
+      isCancelled: true,
+    },
+  });
+
+  verbose(`Streaming payment with ID ${databaseId} waived and cancelled`);
+};

--- a/src/handlers/expenditures/streamingPaymentClaimWaived.ts
+++ b/src/handlers/expenditures/streamingPaymentClaimWaived.ts
@@ -8,8 +8,6 @@ import { ContractEvent } from '~types';
 import { getExpenditureDatabaseId, toNumber, verbose } from '~utils';
 
 export default async (event: ContractEvent): Promise<void> => {
-  console.log('ROMEO IM IN!');
-
   const { colonyAddress } = event;
   const { streamingPaymentId } = event.args;
   const convertedNativeId = toNumber(streamingPaymentId);

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -99,7 +99,7 @@ export enum ContractEventsSignatures {
   PaymentTokenUpdated = 'PaymentTokenUpdated(address,uint256,address,uint256)',
   StartTimeSet = 'StartTimeSet(address,uint256,uint256)',
   EndTimeSet = 'EndTimeSet(address,uint256,uint256)',
-  ClaimWaived = 'ClaimWaived(address,uint256,address)',
+  ClaimWaived = 'ClaimWaived(address,uint256)',
   StreamingPaymentClaimed = 'StreamingPaymentClaimed(address,uint256,address,uint256)',
 
   // Annotations


### PR DESCRIPTION
## Description

This is a dependency of [colonyCDapp#2515: Feat: Handle the cancelAndWaive method call for Streaming Payments](https://github.com/JoinColony/colonyCDapp/pull/2515)