### PR TITLE
Feat: enable handler for the cancel streaming payment motion

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -382,6 +382,8 @@ export enum ColonyActionType {
   /** An action related to adding verified members */
   AddVerifiedMembers = 'ADD_VERIFIED_MEMBERS',
   AddVerifiedMembersMotion = 'ADD_VERIFIED_MEMBERS_MOTION',
+  /** An action related to cancelling and waiving a streaming payment */
+  CancelAndWaiveStreamingPayment = 'CANCEL_AND_WAIVE_STREAMING_PAYMENT',
   /** An action related to canceling an expenditure */
   CancelExpenditure = 'CANCEL_EXPENDITURE',
   /** An action related to a motion to cancel an expenditure */
@@ -1495,6 +1497,7 @@ export type CreateStreamingPaymentInput = {
   id?: InputMaybe<Scalars['ID']>;
   interval: Scalars['String'];
   isCancelled?: InputMaybe<Scalars['Boolean']>;
+  isWaived?: InputMaybe<Scalars['Boolean']>;
   nativeDomainId: Scalars['Int'];
   nativeId: Scalars['Int'];
   recipientAddress: Scalars['String'];
@@ -3417,6 +3420,7 @@ export type ModelStreamingPaymentConditionInput = {
   endTime?: InputMaybe<ModelIntInput>;
   interval?: InputMaybe<ModelStringInput>;
   isCancelled?: InputMaybe<ModelBooleanInput>;
+  isWaived?: InputMaybe<ModelBooleanInput>;
   nativeDomainId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelStreamingPaymentConditionInput>;
@@ -3445,6 +3449,7 @@ export type ModelStreamingPaymentFilterInput = {
   id?: InputMaybe<ModelIdInput>;
   interval?: InputMaybe<ModelStringInput>;
   isCancelled?: InputMaybe<ModelBooleanInput>;
+  isWaived?: InputMaybe<ModelBooleanInput>;
   nativeDomainId?: InputMaybe<ModelIntInput>;
   nativeId?: InputMaybe<ModelIntInput>;
   not?: InputMaybe<ModelStreamingPaymentFilterInput>;
@@ -4016,6 +4021,7 @@ export type ModelSubscriptionStreamingPaymentFilterInput = {
   id?: InputMaybe<ModelSubscriptionIdInput>;
   interval?: InputMaybe<ModelSubscriptionStringInput>;
   isCancelled?: InputMaybe<ModelSubscriptionBooleanInput>;
+  isWaived?: InputMaybe<ModelSubscriptionBooleanInput>;
   nativeDomainId?: InputMaybe<ModelSubscriptionIntInput>;
   nativeId?: InputMaybe<ModelSubscriptionIntInput>;
   or?: InputMaybe<
@@ -6897,6 +6903,8 @@ export type StreamingPayment = {
   interval: Scalars['String'];
   /** Is the stream cancelled? */
   isCancelled?: Maybe<Scalars['Boolean']>;
+  /** Is the stream waived? */
+  isWaived?: Maybe<Scalars['Boolean']>;
   metadata?: Maybe<StreamingPaymentMetadata>;
   nativeDomainId: Scalars['Int'];
   nativeId: Scalars['Int'];
@@ -8111,6 +8119,7 @@ export type UpdateStreamingPaymentInput = {
   id: Scalars['ID'];
   interval?: InputMaybe<Scalars['String']>;
   isCancelled?: InputMaybe<Scalars['Boolean']>;
+  isWaived?: InputMaybe<Scalars['Boolean']>;
   nativeDomainId?: InputMaybe<Scalars['Int']>;
   nativeId?: InputMaybe<Scalars['Int']>;
   recipientAddress?: InputMaybe<Scalars['String']>;

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -388,6 +388,8 @@ export enum ColonyActionType {
   CancelExpenditureMotion = 'CANCEL_EXPENDITURE_MOTION',
   /** An action related to cancelling a streaming payment */
   CancelStreamingPayment = 'CANCEL_STREAMING_PAYMENT',
+  /** An action related to cancelling a streaming payment via a motion */
+  CancelStreamingPaymentMotion = 'CANCEL_STREAMING_PAYMENT_MOTION',
   /** An action related to editing a Colony's details */
   ColonyEdit = 'COLONY_EDIT',
   /** An action related to editing a Colony's details via a motion */

--- a/src/handlers/motions/motionCreated/handlers/index.ts
+++ b/src/handlers/motions/motionCreated/handlers/index.ts
@@ -13,3 +13,4 @@ export { handleMulticallMotion } from './multicall';
 export { handleMakeArbitraryTransactionsMotion } from './makeArbitraryTransactions';
 export { handleMetadataDeltaMotion } from './metadataDelta';
 export * from './expenditures';
+export * from './streamingPayments.ts';

--- a/src/handlers/motions/motionCreated/handlers/streamingPayments.ts/cancelStreamingPaymentsMotion.ts
+++ b/src/handlers/motions/motionCreated/handlers/streamingPayments.ts/cancelStreamingPaymentsMotion.ts
@@ -1,0 +1,35 @@
+import { BigNumber } from 'ethers';
+import { TransactionDescription } from 'ethers/lib/utils';
+import { ContractEvent, motionNameMapping } from '~types';
+import { createMotionInDB } from '../../helpers';
+import {
+  getDomainDatabaseId,
+  getExpenditureDatabaseId,
+  toNumber,
+} from '~utils';
+
+export default async (
+  event: ContractEvent,
+  { name, args: actionArgs }: TransactionDescription,
+  gasEstimate: BigNumber,
+): Promise<void> => {
+  const { args, colonyAddress } = event;
+  const [, , streamingPaymentId] = actionArgs;
+  const [, , domainId] = args;
+
+  if (!colonyAddress) {
+    return;
+  }
+
+  await createMotionInDB(event, {
+    type: motionNameMapping[name],
+    fromDomainId: colonyAddress
+      ? getDomainDatabaseId(colonyAddress, domainId)
+      : undefined,
+    gasEstimate: gasEstimate.toString(),
+    streamingPaymentId: getExpenditureDatabaseId(
+      colonyAddress,
+      toNumber(streamingPaymentId),
+    ),
+  });
+};

--- a/src/handlers/motions/motionCreated/handlers/streamingPayments.ts/cancelStreamingPaymentsMotion.ts
+++ b/src/handlers/motions/motionCreated/handlers/streamingPayments.ts/cancelStreamingPaymentsMotion.ts
@@ -23,9 +23,7 @@ export default async (
 
   await createMotionInDB(event, {
     type: motionNameMapping[name],
-    fromDomainId: colonyAddress
-      ? getDomainDatabaseId(colonyAddress, domainId)
-      : undefined,
+    fromDomainId: getDomainDatabaseId(colonyAddress, domainId),
     gasEstimate: gasEstimate.toString(),
     streamingPaymentId: getExpenditureDatabaseId(
       colonyAddress,

--- a/src/handlers/motions/motionCreated/handlers/streamingPayments.ts/index.ts
+++ b/src/handlers/motions/motionCreated/handlers/streamingPayments.ts/index.ts
@@ -1,0 +1,1 @@
+export { default as handleCancelStreamingPaymentsMotion } from './cancelStreamingPaymentsMotion';

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -6,6 +6,7 @@ import {
   AnyStakedExpenditureClient,
   AnyStagedExpenditureClient,
   AnyVotingReputationClient,
+  AnyStreamingPaymentsClient,
 } from '@colony/colony-js';
 
 import { ColonyOperations, ContractEvent, MotionEvents } from '~types';
@@ -45,6 +46,7 @@ interface MotionActionClients {
   oneTxPaymentClient?: AnyOneTxPaymentClient | null;
   stakedExpenditureClient?: AnyStakedExpenditureClient | null;
   stagedExpenditureClient?: AnyStagedExpenditureClient | null;
+  streamingPaymentsClient?: AnyStreamingPaymentsClient | null;
 }
 
 export const parseAction = (

--- a/src/types/motions.ts
+++ b/src/types/motions.ts
@@ -26,6 +26,10 @@ export enum ColonyOperations {
   ReleaseStagedPaymentViaArbitration = 'releaseStagedPaymentViaArbitration',
 }
 
+export enum StreamingPaymentsOperations {
+  CancelStreamingPayment = 'cancel',
+}
+
 export enum MotionEvents {
   MotionCreated = 'MotionCreated',
   MotionStaked = 'MotionStaked',
@@ -69,6 +73,8 @@ export const motionNameMapping: { [key: string]: ColonyActionType } = {
     ColonyActionType.SetExpenditureStateMotion,
   [ColonyOperations.ReleaseStagedPaymentViaArbitration]:
     ColonyActionType.ReleaseStagedPaymentMotion,
+  [StreamingPaymentsOperations.CancelStreamingPayment]:
+    ColonyActionType.CancelStreamingPaymentMotion,
 };
 
 export enum MotionSide {


### PR DESCRIPTION
These changes are required to test [colonyCDapp#2519: Feat: enable Payment Stream cancellation via a Motion](https://github.com/JoinColony/colonyCDapp/pull/2519)