### PR TITLE
Fix: Manage verified users for multi-sig

### DIFF
--- a/src/handlers/multiSig/multiSigCreated/handlers/index.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/index.ts
@@ -1,3 +1,4 @@
 export { handleMintTokensMultiSig } from './mintTokens';
 export { handleUnlockTokenMultiSig } from './unlockToken';
 export { handleAddOrEditDomainMultiSig } from './addOrEditDomain';
+export { handleMetadataDeltaMultiSig } from './metadataDelta';

--- a/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
@@ -30,14 +30,14 @@ export const handleMetadataDeltaMultiSig = async (
 
     if (isAddVerifiedMembersOperation(operation)) {
       await createMultiSigInDB(colonyAddress, event, {
-        type: ColonyActionType.AddVerifiedMembersMotion,
+        type: ColonyActionType.AddVerifiedMembersMultisig,
         members: operation.payload,
       });
     }
 
     if (isRemoveVerifiedMembersOperation(operation)) {
       await createMultiSigInDB(colonyAddress, event, {
-        type: ColonyActionType.RemoveVerifiedMembersMotion,
+        type: ColonyActionType.RemoveVerifiedMembersMultisig,
         members: operation.payload,
       });
     }

--- a/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
@@ -1,0 +1,47 @@
+import { TransactionDescription } from 'ethers/lib/utils';
+import { ColonyActionType } from '~graphql';
+import { ContractEvent } from '~types';
+import {
+  isAddVerifiedMembersOperation,
+  isRemoveVerifiedMembersOperation,
+  parseMetadataDeltaOperation,
+  verbose,
+} from '~utils';
+import { createMultiSigInDB } from '../helpers';
+
+export const handleMetadataDeltaMultiSig = async (
+  colonyAddress: string,
+  event: ContractEvent,
+  desc: TransactionDescription,
+): Promise<void> => {
+  try {
+    const operationString = desc.args[0];
+
+    if (!operationString) {
+      verbose('Unable to get operation for ColonyMetadataDelta motion event');
+      return;
+    }
+
+    const operation = parseMetadataDeltaOperation(operationString);
+
+    if (operation === null) {
+      return;
+    }
+
+    if (isAddVerifiedMembersOperation(operation)) {
+      await createMultiSigInDB(colonyAddress, event, {
+        type: ColonyActionType.AddVerifiedMembersMotion,
+        members: operation.payload,
+      });
+    }
+
+    if (isRemoveVerifiedMembersOperation(operation)) {
+      await createMultiSigInDB(colonyAddress, event, {
+        type: ColonyActionType.RemoveVerifiedMembersMotion,
+        members: operation.payload,
+      });
+    }
+  } catch (error) {
+    verbose('Error while handling metadata delta motion created', error);
+  }
+};

--- a/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
+++ b/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
@@ -10,11 +10,11 @@ import {
   verbose,
 } from '~utils';
 import {
+  handleMetadataDeltaMultiSig,
   handleMintTokensMultiSig,
   handleUnlockTokenMultiSig,
   handleAddOrEditDomainMultiSig,
 } from './handlers';
-import { handleMetadataDeltaMultiSig } from './handlers/metadataDelta';
 
 export const handleMultiSigMotionCreated: EventHandler = async (
   event,

--- a/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
+++ b/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
@@ -14,6 +14,7 @@ import {
   handleUnlockTokenMultiSig,
   handleAddOrEditDomainMultiSig,
 } from './handlers';
+import { handleMetadataDeltaMultiSig } from './handlers/metadataDelta';
 
 export const handleMultiSigMotionCreated: EventHandler = async (
   event,
@@ -74,6 +75,14 @@ export const handleMultiSigMotionCreated: EventHandler = async (
       case ColonyOperations.AddDomain:
       case ColonyOperations.EditDomain: {
         await handleAddOrEditDomainMultiSig(
+          colonyAddress,
+          event,
+          parsedOperation,
+        );
+        break;
+      }
+      case ColonyOperations.EditColonyByDelta: {
+        await handleMetadataDeltaMultiSig(
           colonyAddress,
           event,
           parsedOperation,


### PR DESCRIPTION
## Description

Create and finalize multi-sig add and remove verified members motions.

- [X] The add verified members multi-sig motion can be created
- [X] The remove verified members multi-sig motion can be created
- [X] The add verified members motion can be finalized
- [X] The remove verified members motion can be finalized
- [X] Only users with [adequate permissions](https://www.notion.so/colony/Multi-sig-Permissions-6aaf0b95309f4754a243d54e8d9c4189?pvs=4#fec3699a5fd241a2925bd2809494b157) can create them


[CDapp PR](https://github.com/JoinColony/colonyCDapp/pull/2650)
