### PR TITLE
Feat: Edit colony description and objective for multi-sig

### DIFF
--- a/src/graphql/fragments/colony.graphql
+++ b/src/graphql/fragments/colony.graphql
@@ -37,6 +37,11 @@ fragment ColonyMetadata on ColonyMetadata {
     name
     link
   }
+  objective {
+    title
+    description
+    progress
+  }
   changelog {
     transactionHash
     oldDisplayName
@@ -45,6 +50,7 @@ fragment ColonyMetadata on ColonyMetadata {
     haveTokensChanged
     hasDescriptionChanged
     haveExternalLinksChanged
+    hasObjectiveChanged
   }
   modifiedTokenAddresses {
     added

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -8829,6 +8829,12 @@ export type ActionMetadataInfoFragment = {
       name: ExternalLinks;
       link: string;
     }> | null;
+    objective?: {
+      __typename?: 'ColonyObjective';
+      title: string;
+      description: string;
+      progress: number;
+    } | null;
     changelog?: Array<{
       __typename?: 'ColonyMetadataChangelog';
       transactionHash: string;
@@ -8838,6 +8844,7 @@ export type ActionMetadataInfoFragment = {
       haveTokensChanged: boolean;
       hasDescriptionChanged?: boolean | null;
       haveExternalLinksChanged?: boolean | null;
+      hasObjectiveChanged?: boolean | null;
     }> | null;
     modifiedTokenAddresses?: {
       __typename?: 'PendingModifiedTokenAddresses';
@@ -8891,6 +8898,12 @@ export type ColonyMetadataFragment = {
     name: ExternalLinks;
     link: string;
   }> | null;
+  objective?: {
+    __typename?: 'ColonyObjective';
+    title: string;
+    description: string;
+    progress: number;
+  } | null;
   changelog?: Array<{
     __typename?: 'ColonyMetadataChangelog';
     transactionHash: string;
@@ -8900,6 +8913,7 @@ export type ColonyMetadataFragment = {
     haveTokensChanged: boolean;
     hasDescriptionChanged?: boolean | null;
     haveExternalLinksChanged?: boolean | null;
+    hasObjectiveChanged?: boolean | null;
   }> | null;
   modifiedTokenAddresses?: {
     __typename?: 'PendingModifiedTokenAddresses';
@@ -9788,6 +9802,12 @@ export type GetColonyMetadataQuery = {
       name: ExternalLinks;
       link: string;
     }> | null;
+    objective?: {
+      __typename?: 'ColonyObjective';
+      title: string;
+      description: string;
+      progress: number;
+    } | null;
     changelog?: Array<{
       __typename?: 'ColonyMetadataChangelog';
       transactionHash: string;
@@ -9797,6 +9817,7 @@ export type GetColonyMetadataQuery = {
       haveTokensChanged: boolean;
       hasDescriptionChanged?: boolean | null;
       haveExternalLinksChanged?: boolean | null;
+      hasObjectiveChanged?: boolean | null;
     }> | null;
     modifiedTokenAddresses?: {
       __typename?: 'PendingModifiedTokenAddresses';
@@ -10349,6 +10370,12 @@ export type GetColonyActionByMotionIdQuery = {
           name: ExternalLinks;
           link: string;
         }> | null;
+        objective?: {
+          __typename?: 'ColonyObjective';
+          title: string;
+          description: string;
+          progress: number;
+        } | null;
         changelog?: Array<{
           __typename?: 'ColonyMetadataChangelog';
           transactionHash: string;
@@ -10358,6 +10385,7 @@ export type GetColonyActionByMotionIdQuery = {
           haveTokensChanged: boolean;
           hasDescriptionChanged?: boolean | null;
           haveExternalLinksChanged?: boolean | null;
+          hasObjectiveChanged?: boolean | null;
         }> | null;
         modifiedTokenAddresses?: {
           __typename?: 'PendingModifiedTokenAddresses';
@@ -10491,6 +10519,12 @@ export type GetColonyActionByMultiSigIdQuery = {
           name: ExternalLinks;
           link: string;
         }> | null;
+        objective?: {
+          __typename?: 'ColonyObjective';
+          title: string;
+          description: string;
+          progress: number;
+        } | null;
         changelog?: Array<{
           __typename?: 'ColonyMetadataChangelog';
           transactionHash: string;
@@ -10500,6 +10534,7 @@ export type GetColonyActionByMultiSigIdQuery = {
           haveTokensChanged: boolean;
           hasDescriptionChanged?: boolean | null;
           haveExternalLinksChanged?: boolean | null;
+          hasObjectiveChanged?: boolean | null;
         }> | null;
         modifiedTokenAddresses?: {
           __typename?: 'PendingModifiedTokenAddresses';
@@ -10739,6 +10774,11 @@ export const ColonyMetadata = gql`
       name
       link
     }
+    objective {
+      title
+      description
+      progress
+    }
     changelog {
       transactionHash
       oldDisplayName
@@ -10747,6 +10787,7 @@ export const ColonyMetadata = gql`
       haveTokensChanged
       hasDescriptionChanged
       haveExternalLinksChanged
+      hasObjectiveChanged
     }
     modifiedTokenAddresses {
       added

--- a/src/handlers/multiSig/multiSigCreated/handlers/editColony.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/editColony.ts
@@ -1,5 +1,5 @@
 import { TransactionDescription } from 'ethers/lib/utils';
-import { ContractEvent, motionNameMapping } from '~types';
+import { ContractEvent, multiSigNameMapping } from '~types';
 import { getPendingMetadataDatabaseId } from '~utils';
 import { createMultiSigInDB } from '../helpers';
 
@@ -18,7 +18,7 @@ export const handleEditColonyMultiSig = async (
     transactionHash,
   );
   await createMultiSigInDB(colonyAddress, event, {
-    type: motionNameMapping[name],
+    type: multiSigNameMapping[name],
     pendingColonyMetadataId,
   });
 };

--- a/src/handlers/multiSig/multiSigCreated/handlers/editColony.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/editColony.ts
@@ -3,7 +3,7 @@ import { ContractEvent, motionNameMapping } from '~types';
 import { getPendingMetadataDatabaseId } from '~utils';
 import { createMultiSigInDB } from '../helpers';
 
-export const handleEditColonyMotion = async (
+export const handleEditColonyMultiSig = async (
   colonyAddress: string,
   event: ContractEvent,
   { name }: TransactionDescription,

--- a/src/handlers/multiSig/multiSigCreated/handlers/editColony.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/editColony.ts
@@ -1,0 +1,24 @@
+import { TransactionDescription } from 'ethers/lib/utils';
+import { ContractEvent, motionNameMapping } from '~types';
+import { getPendingMetadataDatabaseId } from '~utils';
+import { createMultiSigInDB } from '../helpers';
+
+export const handleEditColonyMotion = async (
+  colonyAddress: string,
+  event: ContractEvent,
+  { name }: TransactionDescription,
+): Promise<void> => {
+  const { transactionHash } = event;
+  if (!colonyAddress) {
+    return;
+  }
+
+  const pendingColonyMetadataId = getPendingMetadataDatabaseId(
+    colonyAddress,
+    transactionHash,
+  );
+  await createMultiSigInDB(colonyAddress, event, {
+    type: motionNameMapping[name],
+    pendingColonyMetadataId,
+  });
+};

--- a/src/handlers/multiSig/multiSigCreated/handlers/index.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/index.ts
@@ -1,3 +1,4 @@
+export { handleEditColonyMotion } from './editColony';
 export { handleMintTokensMultiSig } from './mintTokens';
 export { handleMoveFundsMultiSig } from './moveFunds';
 export { handleUnlockTokenMultiSig } from './unlockToken';

--- a/src/handlers/multiSig/multiSigCreated/handlers/index.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/index.ts
@@ -1,4 +1,4 @@
-export { handleEditColonyMotion } from './editColony';
+export { handleEditColonyMultiSig } from './editColony';
 export { handleMintTokensMultiSig } from './mintTokens';
 export { handleMoveFundsMultiSig } from './moveFunds';
 export { handleUnlockTokenMultiSig } from './unlockToken';

--- a/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
+++ b/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
@@ -10,7 +10,7 @@ import {
   verbose,
 } from '~utils';
 import {
-  handleEditColonyMotion,
+  handleEditColonyMultiSig,
   handleMetadataDeltaMultiSig,
   handleMintTokensMultiSig,
   handleMoveFundsMultiSig,
@@ -67,7 +67,7 @@ export const handleMultiSigMotionCreated: EventHandler = async (
     /* Handle the action type-specific mutation here */
     switch (contractOperation) {
       case ColonyOperations.EditColony: {
-        await handleEditColonyMotion(colonyAddress, event, parsedOperation);
+        await handleEditColonyMultiSig(colonyAddress, event, parsedOperation);
         break;
       }
       case ColonyOperations.MintTokens: {

--- a/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
+++ b/src/handlers/multiSig/multiSigCreated/multiSigCreated.ts
@@ -10,6 +10,7 @@ import {
   verbose,
 } from '~utils';
 import {
+  handleEditColonyMotion,
   handleMetadataDeltaMultiSig,
   handleMintTokensMultiSig,
   handleMoveFundsMultiSig,
@@ -65,6 +66,10 @@ export const handleMultiSigMotionCreated: EventHandler = async (
     const contractOperation = parsedOperation.name;
     /* Handle the action type-specific mutation here */
     switch (contractOperation) {
+      case ColonyOperations.EditColony: {
+        await handleEditColonyMotion(colonyAddress, event, parsedOperation);
+        break;
+      }
       case ColonyOperations.MintTokens: {
         await handleMintTokensMultiSig(colonyAddress, event, parsedOperation);
         break;

--- a/src/utils/colonyMetadata.ts
+++ b/src/utils/colonyMetadata.ts
@@ -145,6 +145,7 @@ const linkPendingColonyMetadataWithColony = async (
   }
 
   const {
+    hasObjectiveChanged,
     haveTokensChanged,
     hasAvatarChanged,
     newDisplayName,
@@ -179,6 +180,10 @@ const linkPendingColonyMetadataWithColony = async (
 
   if (haveExternalLinksChanged) {
     updatedMetadata.externalLinks = pendingColonyMetadata.externalLinks;
+  }
+
+  if (hasObjectiveChanged) {
+    updatedMetadata.objective = pendingColonyMetadata.objective;
   }
 
   if (haveTokensChanged && pendingColonyMetadata.modifiedTokenAddresses) {


### PR DESCRIPTION
## Description

Create and finalize a multi-sig edit colony details and manage colony objective motions.

- [X] The edit colony details multi-sig motion can be created
- [X] The manage colony objective multi-sig motion can be created
- [X] The edit colony details motion can be finalized
- [X] The manage colony objective motion can be finalized
- [X] Only users with [adequate permissions](https://www.notion.so/colony/Multi-sig-Permissions-6aaf0b95309f4754a243d54e8d9c4189?pvs=4#fec3699a5fd241a2925bd2809494b157) can create them

[CDapp PR](https://github.com/JoinColony/colonyCDapp/pull/2654)