### PR TITLE
Fix: conditionally add multisig chunk to historic role id

### DIFF
--- a/src/handlers/actions/managePermissions.ts
+++ b/src/handlers/actions/managePermissions.ts
@@ -106,8 +106,9 @@ export const handleManagePermissionsAction: EventHandler = async (
       // We can get the msg.sender from the transaction receipt.
 
       if (!agent) {
-        const { from = '' } =
-          await provider.getTransactionReceipt(transactionHash);
+        const { from = '' } = await provider.getTransactionReceipt(
+          transactionHash,
+        );
         agent = from;
       }
       const allRoleEventsUpdates = isMultiSig
@@ -154,6 +155,7 @@ export const handleManagePermissionsAction: EventHandler = async (
           ...existingRoles,
           ...rolesFromAllUpdateEvents,
         },
+        isMultiSig,
       );
 
       const individualEvents = isMultiSig


### PR DESCRIPTION
This PR fixes an issue with how we build a historic role's ID.

Historic roles IDs will now conditionally have the "_multisig" chunk when a multi-sig role is being processed.

Please test this as part of: [colonyCDapp#2773: Auto-populate the Role and Permissions fields in the Manage Permissions form ](https://github.com/JoinColony/colonyCDapp/pull/2773)