### PR TITLE
feat: remove gas estimation for motions

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -959,11 +959,6 @@ export type ColonyMotion = {
   expenditureId?: Maybe<Scalars['ID']>;
   /** Id of the expenditure stage payment to be released if the motion pass, if any */
   expenditureSlotId?: Maybe<Scalars['Int']>;
-  /**
-   * An option to manually specify the amount of gas to estimate for the finalization of this motion.
-   * Particularly useful for "heavy" actions, such as a multicall.
-   */
-  gasEstimate: Scalars['String'];
   /** Simple flag indicating whether both sides of staking have been activated */
   hasObjection: Scalars['Boolean'];
   /**
@@ -1407,7 +1402,6 @@ export type CreateColonyMotionInput = {
   expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
   expenditureId?: InputMaybe<Scalars['ID']>;
   expenditureSlotId?: InputMaybe<Scalars['Int']>;
-  gasEstimate: Scalars['String'];
   hasObjection: Scalars['Boolean'];
   id?: InputMaybe<Scalars['ID']>;
   isDecision: Scalars['Boolean'];
@@ -2835,7 +2829,6 @@ export type ModelColonyMotionConditionInput = {
   createdBy?: InputMaybe<ModelStringInput>;
   expenditureId?: InputMaybe<ModelIdInput>;
   expenditureSlotId?: InputMaybe<ModelIntInput>;
-  gasEstimate?: InputMaybe<ModelStringInput>;
   hasObjection?: InputMaybe<ModelBooleanInput>;
   isDecision?: InputMaybe<ModelBooleanInput>;
   isFinalized?: InputMaybe<ModelBooleanInput>;
@@ -2864,7 +2857,6 @@ export type ModelColonyMotionFilterInput = {
   createdBy?: InputMaybe<ModelStringInput>;
   expenditureId?: InputMaybe<ModelIdInput>;
   expenditureSlotId?: InputMaybe<ModelIntInput>;
-  gasEstimate?: InputMaybe<ModelStringInput>;
   hasObjection?: InputMaybe<ModelBooleanInput>;
   id?: InputMaybe<ModelIdInput>;
   isDecision?: InputMaybe<ModelBooleanInput>;
@@ -3869,7 +3861,6 @@ export type ModelSubscriptionColonyMotionFilterInput = {
   createdBy?: InputMaybe<ModelSubscriptionStringInput>;
   expenditureId?: InputMaybe<ModelSubscriptionIdInput>;
   expenditureSlotId?: InputMaybe<ModelSubscriptionIntInput>;
-  gasEstimate?: InputMaybe<ModelSubscriptionStringInput>;
   hasObjection?: InputMaybe<ModelSubscriptionBooleanInput>;
   id?: InputMaybe<ModelSubscriptionIdInput>;
   isDecision?: InputMaybe<ModelSubscriptionBooleanInput>;
@@ -8100,7 +8091,6 @@ export type UpdateColonyMotionInput = {
   expenditureFunding?: InputMaybe<Array<ExpenditureFundingItemInput>>;
   expenditureId?: InputMaybe<Scalars['ID']>;
   expenditureSlotId?: InputMaybe<Scalars['Int']>;
-  gasEstimate?: InputMaybe<Scalars['String']>;
   hasObjection?: InputMaybe<Scalars['Boolean']>;
   id: Scalars['ID'];
   isDecision?: InputMaybe<Scalars['Boolean']>;

--- a/src/handlers/motions/motionCreated/handlers/addDomain.ts
+++ b/src/handlers/motions/motionCreated/handlers/addDomain.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { getPendingMetadataDatabaseId } from '~utils';
@@ -8,7 +7,6 @@ export const handleAddDomainMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { transactionHash } = event;
   if (!colonyAddress) {
@@ -25,6 +23,5 @@ export const handleAddDomainMotion = async (
   await createMotionInDB(colonyAddress, event, {
     type: motionNameMapping[name],
     pendingDomainMetadataId,
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/editColony.ts
+++ b/src/handlers/motions/motionCreated/handlers/editColony.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { getPendingMetadataDatabaseId } from '~utils';
@@ -8,7 +7,6 @@ export const handleEditColonyMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   { name }: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { transactionHash } = event;
   if (!colonyAddress) {
@@ -22,6 +20,5 @@ export const handleEditColonyMotion = async (
   await createMotionInDB(colonyAddress, event, {
     type: motionNameMapping[name],
     pendingColonyMetadataId,
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/editDomain.ts
+++ b/src/handlers/motions/motionCreated/handlers/editDomain.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { getDomainDatabaseId, getPendingMetadataDatabaseId } from '~utils';
@@ -8,7 +7,6 @@ export const handleEditDomainMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { transactionHash } = event;
   if (!colonyAddress) {
@@ -27,6 +25,5 @@ export const handleEditDomainMotion = async (
     type: motionNameMapping[name],
     pendingDomainMetadataId,
     fromDomainId: getDomainDatabaseId(colonyAddress, nativeDomainId),
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/expenditures/cancelExpenditureViaArbitration.ts
+++ b/src/handlers/motions/motionCreated/handlers/expenditures/cancelExpenditureViaArbitration.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { createMotionInDB } from '../../helpers';
@@ -12,7 +11,6 @@ export default async (
   colonyAddress: string,
   event: ContractEvent,
   { name, args: actionArgs }: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { args } = event;
   const [, , expenditureId] = actionArgs;
@@ -27,7 +25,6 @@ export default async (
     fromDomainId: colonyAddress
       ? getDomainDatabaseId(colonyAddress, domainId)
       : undefined,
-    gasEstimate: gasEstimate.toString(),
     expenditureId: getExpenditureDatabaseId(
       colonyAddress,
       toNumber(expenditureId),

--- a/src/handlers/motions/motionCreated/handlers/expenditures/cancelStakedExpenditures.ts
+++ b/src/handlers/motions/motionCreated/handlers/expenditures/cancelStakedExpenditures.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { createMotionInDB } from '../../helpers';
@@ -12,7 +11,6 @@ export default async (
   colonyAddress: string,
   event: ContractEvent,
   { name, args: actionArgs }: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { args } = event;
   const [, , , , expenditureId] = actionArgs;
@@ -23,7 +21,6 @@ export default async (
     fromDomainId: colonyAddress
       ? getDomainDatabaseId(colonyAddress, domainId)
       : undefined,
-    gasEstimate: gasEstimate.toString(),
     expenditureId: getExpenditureDatabaseId(
       colonyAddress,
       toNumber(expenditureId),

--- a/src/handlers/motions/motionCreated/handlers/expenditures/finalizeExpenditureViaArbitration.ts
+++ b/src/handlers/motions/motionCreated/handlers/expenditures/finalizeExpenditureViaArbitration.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { createMotionInDB } from '../../helpers';
@@ -12,7 +11,6 @@ export default async (
   colonyAddress: string,
   event: ContractEvent,
   { name, args: actionArgs }: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { args } = event;
   const [, , expenditureId] = actionArgs;
@@ -27,7 +25,6 @@ export default async (
     fromDomainId: colonyAddress
       ? getDomainDatabaseId(colonyAddress, domainId)
       : undefined,
-    gasEstimate: gasEstimate.toString(),
     expenditureId: getExpenditureDatabaseId(
       colonyAddress,
       toNumber(expenditureId),

--- a/src/handlers/motions/motionCreated/handlers/makeArbitraryTransactions.ts
+++ b/src/handlers/motions/motionCreated/handlers/makeArbitraryTransactions.ts
@@ -1,6 +1,5 @@
 import { TransactionDescription } from 'ethers/lib/utils';
 import { Id } from '@colony/colony-js';
-import { BigNumber } from 'ethers';
 import { ContractEvent, motionNameMapping } from '~types';
 import { getDomainDatabaseId } from '~utils';
 
@@ -10,7 +9,6 @@ export const handleMakeArbitraryTransactionsMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { name, args: actionArgs } = parsedAction;
   const [recipients] = actionArgs;
@@ -19,6 +17,5 @@ export const handleMakeArbitraryTransactionsMotion = async (
     type: motionNameMapping[name],
     recipientAddress: recipients[0],
     fromDomainId: getDomainDatabaseId(colonyAddress, Id.RootDomain),
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
+++ b/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ColonyActionType } from '~graphql';
 import { ContractEvent } from '~types';
@@ -16,7 +15,6 @@ export const handleMetadataDeltaMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   desc: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   try {
     const operationString = desc.args[0];
@@ -36,7 +34,6 @@ export const handleMetadataDeltaMotion = async (
       await createMotionInDB(colonyAddress, event, {
         type: ColonyActionType.AddVerifiedMembersMotion,
         members: operation.payload,
-        gasEstimate: gasEstimate.toString(),
       });
     }
 
@@ -44,7 +41,6 @@ export const handleMetadataDeltaMotion = async (
       await createMotionInDB(colonyAddress, event, {
         type: ColonyActionType.RemoveVerifiedMembersMotion,
         members: operation.payload,
-        gasEstimate: gasEstimate.toString(),
       });
     }
 
@@ -52,7 +48,6 @@ export const handleMetadataDeltaMotion = async (
       await manageTokensMotionHandler({
         colonyAddress,
         event,
-        gasEstimate,
         operation,
       });
     }

--- a/src/handlers/motions/motionCreated/handlers/metadataDeltaHandlers/manageTokens.ts
+++ b/src/handlers/motions/motionCreated/handlers/metadataDeltaHandlers/manageTokens.ts
@@ -6,17 +6,14 @@ import {
 import { createMotionInDB } from '../../helpers';
 import { ColonyActionType } from '~graphql';
 import { ContractEvent } from '~types';
-import { BigNumber } from 'ethers';
 
 export const manageTokensMotionHandler = async ({
   colonyAddress,
   event,
-  gasEstimate,
   operation,
 }: {
   colonyAddress: string;
   event: ContractEvent;
-  gasEstimate: BigNumber;
   operation: MetadataDeltaOperation;
 }): Promise<void> => {
   const tokenAddresses = operation.payload;
@@ -40,6 +37,5 @@ export const manageTokensMotionHandler = async ({
       removed: modifiedTokenAddresses.removed,
       unaffected: unaffectedTokenAddresses,
     },
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/mintTokens.ts
+++ b/src/handlers/motions/motionCreated/handlers/mintTokens.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { getColonyTokenAddress, getDomainDatabaseId } from '~utils';
@@ -8,7 +7,6 @@ export const handleMintTokensMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const {
     args: { domainId },
@@ -26,6 +24,5 @@ export const handleMintTokensMotion = async (
     tokenAddress,
     fromDomainId: getDomainDatabaseId(colonyAddress, domainId),
     amount,
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/moveFunds.ts
+++ b/src/handlers/motions/motionCreated/handlers/moveFunds.ts
@@ -15,7 +15,6 @@ export const handleMoveFundsMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { blockNumber } = event;
 
@@ -64,6 +63,5 @@ export const handleMoveFundsMotion = async (
     toDomainId: toDomainId
       ? getDomainDatabaseId(colonyAddress, toNumber(toDomainId))
       : undefined,
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/multicall/multicall.ts
+++ b/src/handlers/motions/motionCreated/handlers/multicall/multicall.ts
@@ -1,5 +1,5 @@
 import { Result, TransactionDescription } from 'ethers/lib/utils';
-import { BigNumber, utils } from 'ethers';
+import { utils } from 'ethers';
 import { getCachedColonyClient, output } from '~utils';
 import { ContractEvent, ContractMethodSignatures } from '~types';
 import { AnyColonyClient } from '@colony/colony-js';
@@ -52,7 +52,6 @@ export const handleMulticallMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const colonyClient = await getCachedColonyClient(colonyAddress);
 
@@ -63,12 +62,6 @@ export const handleMulticallMotion = async (
   // Multicall takes an array of an array of encoded function calls
   const encodedFunctions = parsedAction.args[0];
 
-  // Multicall can have an arbitrary number of underlying function calls. Difficult to predict in advance how much
-  // gas executing this action will consume. Let's start by assuming 100k gas per action.
-  const updatedGasEstimate = gasEstimate
-    .add(BigNumber.from(encodedFunctions.length ?? 0).mul(100000))
-    .toString();
-
   // We need to determine which multicallMotion this is and pass it to the appropriate handler
   const decodedFunctions = decodeFunctions(encodedFunctions, colonyClient);
 
@@ -78,7 +71,6 @@ export const handleMulticallMotion = async (
         colonyAddress,
         event,
         decodedFunctions,
-        gasEstimate: updatedGasEstimate,
       });
 
       return;

--- a/src/handlers/motions/motionCreated/handlers/multicall/multicallHandlers/editLockedExpenditureMotion.ts
+++ b/src/handlers/motions/motionCreated/handlers/multicall/multicallHandlers/editLockedExpenditureMotion.ts
@@ -27,7 +27,6 @@ export const isEditLockedExpenditureMotion: MulticallValidator = ({
 export const editLockedExpenditureMotionHandler: MulticallHandler = async ({
   colonyAddress,
   event,
-  gasEstimate,
   decodedFunctions,
 }) => {
   /**
@@ -106,7 +105,6 @@ export const editLockedExpenditureMotionHandler: MulticallHandler = async ({
 
   createMotionInDB(colonyAddress, event, {
     type: ColonyActionType.EditExpenditureMotion,
-    gasEstimate,
     expenditureId: expenditure.id,
     editedExpenditureSlots: updatedSlots,
   });

--- a/src/handlers/motions/motionCreated/handlers/multicall/multicallHandlers/fundExpenditureMotion.ts
+++ b/src/handlers/motions/motionCreated/handlers/multicall/multicallHandlers/fundExpenditureMotion.ts
@@ -25,7 +25,6 @@ export const fundExpenditureMotionHandler: MulticallHandler = async ({
   colonyAddress,
   event,
   decodedFunctions,
-  gasEstimate,
 }) => {
   // @NOTE: We get the target pot ID from the first multicall function
   // This means if the multicall funds multiple expenditures, we will only create a motion for the first one
@@ -66,7 +65,6 @@ export const fundExpenditureMotionHandler: MulticallHandler = async ({
 
   await createMotionInDB(colonyAddress, event, {
     type: ColonyActionType.FundExpenditureMotion,
-    gasEstimate,
     expenditureId: expenditure.id,
     expenditureFunding: fundingItems,
   });

--- a/src/handlers/motions/motionCreated/handlers/multicall/multicallHandlers/types.ts
+++ b/src/handlers/motions/motionCreated/handlers/multicall/multicallHandlers/types.ts
@@ -4,14 +4,12 @@ import { DecodedFunction } from '../multicall';
 interface MulticallHandlerParams {
   colonyAddress: string;
   event: ContractEvent;
-  gasEstimate: string;
   decodedFunctions: DecodedFunction[];
 }
 
 export type MulticallHandler = ({
   event,
   decodedFunctions,
-  gasEstimate,
 }: MulticallHandlerParams) => void | Promise<void>;
 
 export type MulticallValidator = ({

--- a/src/handlers/motions/motionCreated/handlers/networkUpgrade.ts
+++ b/src/handlers/motions/motionCreated/handlers/networkUpgrade.ts
@@ -1,5 +1,4 @@
 import { TransactionDescription } from 'ethers/lib/utils';
-import { BigNumber } from 'ethers';
 
 import { ContractEvent, motionNameMapping } from '~types';
 import { toNumber } from '~utils';
@@ -10,13 +9,11 @@ export const handleNetworkUpgradeMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { name, args: actionArgs } = parsedAction;
   const newVersion = actionArgs[0];
   await createMotionInDB(colonyAddress, event, {
     type: motionNameMapping[name],
     newColonyVersion: toNumber(newVersion),
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/payment.ts
+++ b/src/handlers/motions/motionCreated/handlers/payment.ts
@@ -1,5 +1,4 @@
 import { TransactionDescription } from 'ethers/lib/utils';
-import { BigNumber } from 'ethers';
 
 import { ContractEvent, motionNameMapping } from '~types';
 import { getDomainDatabaseId, toNumber } from '~utils';
@@ -13,7 +12,6 @@ export const handlePaymentMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { name, args: actionArgs } = parsedAction;
   const [, , , , recipients, tokenAddresses, amounts, fromDomainId] =
@@ -26,7 +24,6 @@ export const handlePaymentMotion = async (
       tokenAddress: tokenAddresses[0],
       amount: amounts[0].toString(),
       recipientAddress: recipients[0],
-      gasEstimate: gasEstimate.toString(),
     });
   } else {
     const payments = (recipients as string[]).map((recipient, idx) => {
@@ -42,7 +39,6 @@ export const handlePaymentMotion = async (
       type: ColonyActionType.MultiplePaymentMotion,
       fromDomainId: getDomainDatabaseId(colonyAddress, toNumber(fromDomainId)),
       payments,
-      gasEstimate: gasEstimate.toString(),
     });
   }
 };

--- a/src/handlers/motions/motionCreated/handlers/reputation.ts
+++ b/src/handlers/motions/motionCreated/handlers/reputation.ts
@@ -1,5 +1,4 @@
 import { TransactionDescription } from 'ethers/lib/utils';
-import { BigNumber } from 'ethers';
 import { ContractEvent, motionNameMapping } from '~types';
 import { getDomainDatabaseId } from '~utils';
 
@@ -9,7 +8,6 @@ export const handleDomainEditReputationMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { name, args: actionArgs } = parsedAction;
   const [domainId, userAddress, amount] = actionArgs.slice(-3);
@@ -18,6 +16,5 @@ export const handleDomainEditReputationMotion = async (
     recipientAddress: userAddress,
     amount: amount.toString(),
     fromDomainId: getDomainDatabaseId(colonyAddress, domainId),
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/setUserRoles.ts
+++ b/src/handlers/motions/motionCreated/handlers/setUserRoles.ts
@@ -1,5 +1,4 @@
 import { TransactionDescription } from 'ethers/lib/utils';
-import { BigNumber } from 'ethers';
 
 import { ContractEvent, motionNameMapping } from '~types';
 import {
@@ -14,7 +13,6 @@ export const handleSetUserRolesMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { name, args: actionArgs } = parsedAction;
   const [userAddress, domainId, zeroPadHexString] = actionArgs.slice(-3);
@@ -33,6 +31,5 @@ export const handleSetUserRolesMotion = async (
     fromDomainId: getDomainDatabaseId(colonyAddress, domainId),
     recipientAddress: userAddress,
     roles,
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/simpleDecision.ts
+++ b/src/handlers/motions/motionCreated/handlers/simpleDecision.ts
@@ -1,5 +1,3 @@
-import { BigNumber } from 'ethers';
-
 import { ContractEvent, motionNameMapping } from '~types';
 import { getColonyDecisionId } from '~utils/decisions';
 
@@ -9,7 +7,6 @@ export const handleSimpleDecisionMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: SimpleTransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { transactionHash } = event;
 
@@ -18,6 +15,5 @@ export const handleSimpleDecisionMotion = async (
   await createMotionInDB(colonyAddress, event, {
     type: motionNameMapping[name],
     colonyDecisionId: getColonyDecisionId(colonyAddress, transactionHash),
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/handlers/unlockToken.ts
+++ b/src/handlers/motions/motionCreated/handlers/unlockToken.ts
@@ -1,5 +1,4 @@
 import { Id } from '@colony/colony-js';
-import { BigNumber } from 'ethers';
 import { TransactionDescription } from 'ethers/lib/utils';
 import { ContractEvent, motionNameMapping } from '~types';
 import { getColonyTokenAddress, getDomainDatabaseId } from '~utils';
@@ -9,7 +8,6 @@ export const handleUnlockTokenMotion = async (
   colonyAddress: string,
   event: ContractEvent,
   parsedAction: TransactionDescription,
-  gasEstimate: BigNumber,
 ): Promise<void> => {
   const { blockNumber } = event;
 
@@ -20,6 +18,5 @@ export const handleUnlockTokenMotion = async (
     type: motionNameMapping[name],
     fromDomainId: getDomainDatabaseId(colonyAddress, Id.RootDomain),
     tokenAddress,
-    gasEstimate: gasEstimate.toString(),
   });
 };

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -238,10 +238,7 @@ type MotionFields = Omit<
 > &
   Pick<
     CreateColonyMotionInput,
-    | 'gasEstimate'
-    | 'expenditureSlotId'
-    | 'editedExpenditureSlots'
-    | 'expenditureFunding'
+    'expenditureSlotId' | 'editedExpenditureSlots' | 'expenditureFunding'
   >;
 
 export const createMotionInDB = async (
@@ -257,7 +254,6 @@ export const createMotionInDB = async (
     timestamp,
   } = event;
   const {
-    gasEstimate,
     expenditureSlotId,
     editedExpenditureSlots,
     expenditureFunding,
@@ -306,7 +302,6 @@ export const createMotionInDB = async (
   await Promise.all([
     createColonyMotion({
       ...motionData,
-      gasEstimate,
       expenditureId: actionFields.expenditureId,
       expenditureSlotId,
       editedExpenditureSlots,

--- a/src/handlers/motions/motionCreated/motionCreated.ts
+++ b/src/handlers/motions/motionCreated/motionCreated.ts
@@ -1,6 +1,3 @@
-import { BigNumber, constants } from 'ethers';
-import { StaticJsonRpcProvider } from '@ethersproject/providers';
-
 import { ColonyOperations, EventHandler } from '~types';
 import {
   getCachedColonyClient,
@@ -69,134 +66,41 @@ export const handleMotionCreated: EventHandler = async (
     stagedExpenditureClient,
   });
 
-  let gasEstimate: BigNumber;
-
-  const estimateMotionGas = async (): Promise<string> =>
-    /*
-     * @NOTE Express casting required here since colonyJS forces it's own types internally
-     * Even though we instantiate the initial network client with a StaticJsonRpcProvider, colonyJS
-     * will internally cast it to a BaseProvider which is a generic type that doesn't declare
-     * all the methods actually available on the provider
-     *
-     * Alternatively, we could just import our provider directly and use that instead
-     *
-     * Ultimately it's the same thing as the provider instance is the same
-     */
-    await (colonyClient.provider as StaticJsonRpcProvider).send(
-      'eth_estimateGas',
-      [
-        {
-          from: votingReputationClient.address,
-          to:
-            /*
-             * If the motion target is 0x000... then we pass in the colony's address
-             */
-            motion.altTarget === constants.AddressZero
-              ? colonyClient.address
-              : motion.altTarget,
-          data: motion.action,
-        },
-        blockNumber,
-      ],
-    );
-
-  try {
-    const estimatedGasHexString = await estimateMotionGas();
-    gasEstimate = BigNumber.from(estimatedGasHexString);
-  } catch {
-    // Sometimes the call to estimate gas fails. Let's try one more time...
-    try {
-      const estimatedGasHexString = await estimateMotionGas();
-      gasEstimate = BigNumber.from(estimatedGasHexString);
-    } catch {
-      const manualEstimate = 500_000;
-      // If it fails again, let's just set it manually.
-      console.error(
-        `Unable to estimate gas for motion's action. Manually setting to ${manualEstimate}`,
-      );
-      gasEstimate = BigNumber.from(manualEstimate);
-    }
-  }
-
-  /*
-   * Increase the estimate by 100k WEI. This is a flat increase for all networks
-   *
-   * @NOTE This will need to be increased further for `setExpenditureState` since
-   * that requires even more gas, but since we don't use that one yet, there's
-   * no reason to account for it just yet
-   */
-  gasEstimate = gasEstimate.add(100_000);
-
   if (parsedAction) {
     const contractOperation = parsedAction.name;
     /* Handle the action type-specific mutation here */
     switch (contractOperation) {
       case ColonyOperations.MintTokens: {
-        await handleMintTokensMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleMintTokensMotion(colonyAddress, event, parsedAction);
         break;
       }
       case ColonyOperations.AddDomain: {
-        await handleAddDomainMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleAddDomainMotion(colonyAddress, event, parsedAction);
         break;
       }
 
       case ColonyOperations.EditDomain: {
-        await handleEditDomainMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleEditDomainMotion(colonyAddress, event, parsedAction);
         break;
       }
 
       case ColonyOperations.Upgrade: {
-        await handleNetworkUpgradeMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleNetworkUpgradeMotion(colonyAddress, event, parsedAction);
         break;
       }
 
       case ColonyOperations.UnlockToken: {
-        await handleUnlockTokenMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleUnlockTokenMotion(colonyAddress, event, parsedAction);
         break;
       }
 
       case ColonyOperations.MakePaymentFundedFromDomain: {
-        await handlePaymentMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handlePaymentMotion(colonyAddress, event, parsedAction);
         break;
       }
 
       case ColonyOperations.MoveFundsBetweenPots: {
-        await handleMoveFundsMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleMoveFundsMotion(colonyAddress, event, parsedAction);
         break;
       }
 
@@ -206,38 +110,22 @@ export const handleMotionCreated: EventHandler = async (
           colonyAddress,
           event,
           parsedAction,
-          gasEstimate,
         );
         break;
       }
 
       case ColonyOperations.EditColony: {
-        await handleEditColonyMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleEditColonyMotion(colonyAddress, event, parsedAction);
         break;
       }
 
       case ColonyOperations.SetUserRoles: {
-        await handleSetUserRolesMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleSetUserRolesMotion(colonyAddress, event, parsedAction);
         break;
       }
 
       case ColonyOperations.Multicall: {
-        await handleMulticallMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleMulticallMotion(colonyAddress, event, parsedAction);
         break;
       }
 
@@ -246,7 +134,6 @@ export const handleMotionCreated: EventHandler = async (
           colonyAddress,
           event,
           parsedAction as SimpleTransactionDescription,
-          gasEstimate,
         );
         break;
       }
@@ -256,7 +143,6 @@ export const handleMotionCreated: EventHandler = async (
           colonyAddress,
           event,
           parsedAction,
-          gasEstimate,
         );
 
         break;
@@ -267,18 +153,12 @@ export const handleMotionCreated: EventHandler = async (
           colonyAddress,
           event,
           parsedAction,
-          gasEstimate,
         );
         break;
       }
 
       case ColonyOperations.EditColonyByDelta: {
-        await handleMetadataDeltaMotion(
-          colonyAddress,
-          event,
-          parsedAction,
-          gasEstimate,
-        );
+        await handleMetadataDeltaMotion(colonyAddress, event, parsedAction);
         break;
       }
 
@@ -287,7 +167,6 @@ export const handleMotionCreated: EventHandler = async (
           colonyAddress,
           event,
           parsedAction,
-          gasEstimate,
         );
         break;
       }
@@ -297,7 +176,6 @@ export const handleMotionCreated: EventHandler = async (
           colonyAddress,
           event,
           parsedAction,
-          gasEstimate,
         );
         break;
       }


### PR DESCRIPTION
This PR removes all gas estimation from the block ingestor in favor of calling different contracts as defined in its [CDapp counterpart](https://github.com/JoinColony/colonyCDapp/pull/2817)