### PR TITLE
Fix: Reveal domain for manage tokens action

### DIFF
--- a/src/handlers/metadataDelta/handlers/manageTokens.ts
+++ b/src/handlers/metadataDelta/handlers/manageTokens.ts
@@ -1,9 +1,11 @@
+import { Id } from '@colony/colony-js';
 import { ColonyActionType } from '~graphql';
 import { ContractEvent } from '~types';
 import {
   ManageTokensOperation,
   getApprovedTokenChanges,
   getColonyFromDB,
+  getDomainDatabaseId,
   updateColonyTokens,
   writeActionFromEvent,
 } from '~utils';
@@ -46,5 +48,6 @@ export const handleManageTokens = async (
       removed: modifiedTokenAddresses.removed,
       unaffected: unaffectedTokenAddresses,
     },
+    fromDomainId: getDomainDatabaseId(colonyAddress, Id.RootDomain),
   });
 };


### PR DESCRIPTION
This just simply adds a `fromDomainId` entry which ends up exposing the `fromDomain.metadata` information for the action.

Please test this as part of [colonyCDapp#2944 Fix: Reveal domain for manage tokens action
](https://github.com/JoinColony/colonyCDapp/pull/2944)