### PR TITLE
Temp: Prevent expenditure balance from going below 0, add logs

### DIFF
--- a/src/handlers/actions/moveFunds.ts
+++ b/src/handlers/actions/moveFunds.ts
@@ -10,6 +10,7 @@ import {
   getUpdatedExpenditureBalances,
   transactionHasEvent,
   getExpenditureByFundingPot,
+  verbose,
 } from '~utils';
 import {
   ColonyActionType,
@@ -85,6 +86,11 @@ export default async (event: ContractEvent): Promise<void> => {
 
   if (targetExpenditure) {
     await updateExpenditureBalances(targetExpenditure, tokenAddress, amount);
+  } else {
+    // @NOTE: Temporary log until issue with negative balances is resolved
+    verbose(
+      `Attempted to find expenditure with funding pot ID: ${toPotId} in colony ${colonyAddress} but it wasn't found. It may be because the transfer was to a domain, or there was a bug.`,
+    );
   }
 };
 
@@ -94,7 +100,7 @@ const updateExpenditureBalances = async (
   amount: string,
 ): Promise<void> => {
   const updatedBalances = getUpdatedExpenditureBalances(
-    expenditure.balances ?? [],
+    expenditure,
     tokenAddress,
     amount,
   );

--- a/src/handlers/expenditures/expenditurePayoutClaimed.ts
+++ b/src/handlers/expenditures/expenditurePayoutClaimed.ts
@@ -78,7 +78,7 @@ export default async (event: ContractEvent): Promise<void> => {
   ).toString();
 
   const updatedBalances = getUpdatedExpenditureBalances(
-    expenditure.balances ?? [],
+    expenditure,
     tokenAddress,
     amountWithFee,
     true,

--- a/src/utils/expenditures.ts
+++ b/src/utils/expenditures.ts
@@ -54,12 +54,14 @@ export const getUpdatedExpenditureBalances = (
     );
     updatedAmount = BigNumber.from(0);
 
-    fetch('https://hooks.zapier.com/hooks/catch/20362233/2mnk4h2', {
-      method: 'POST',
-      body: JSON.stringify({
-        message: `Balance of expenditure ${expenditure.id} for token ${tokenAddress} would go negative. This is a bug and needs investigating.`,
-      }),
-    });
+    if (process.env.NODE_ENV !== 'development') {
+      fetch('https://hooks.zapier.com/hooks/catch/20362233/2mnk4h2', {
+        method: 'POST',
+        body: JSON.stringify({
+          message: `Balance of expenditure ${expenditure.id} for token ${tokenAddress} would go negative. This is a bug and needs investigating.`,
+        }),
+      });
+    }
   }
 
   const updatedBalance = {


### PR DESCRIPTION
This is a temporary change that mitigates the issue where the expenditure balance drops below 0, affecting the total colony balance.

The current theory is that it's due to a race condition in DynamoDB, meaning the expenditure is not in the DB by the time we process the funds transferred into the expenditure's pot. On the other hand the expenditure is returned when payout is claimed, leading to the negative balance.