### PR TITLE
Dont send mention notifications to the same address as the creator

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -279,11 +279,11 @@ export const sendMentionNotifications = async ({
   expenditureID,
   recipients,
 }: MentionNotificationVariables): Promise<void> => {
-  const nonSelfRecipients = recipients.filter(
+  const recipientsExcludingCreator = recipients.filter(
     (recipient) => recipient !== creator,
   );
 
-  if (!nonSelfRecipients.length) {
+  if (!recipientsExcludingCreator.length) {
     return;
   }
 
@@ -292,7 +292,9 @@ export const sendMentionNotifications = async ({
     GetNotificationUsersQueryVariables
   >(GetNotificationUsersDocument, {
     filter: {
-      or: nonSelfRecipients.map((address) => ({ id: { eq: address } })),
+      or: recipientsExcludingCreator.map((address) => ({
+        id: { eq: address },
+      })),
     },
     limit: 9999,
   });

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -279,7 +279,11 @@ export const sendMentionNotifications = async ({
   expenditureID,
   recipients,
 }: MentionNotificationVariables): Promise<void> => {
-  if (!recipients.length) {
+  const nonSelfRecipients = recipients.filter(
+    (recipient) => recipient !== creator,
+  );
+
+  if (!nonSelfRecipients.length) {
     return;
   }
 
@@ -288,7 +292,7 @@ export const sendMentionNotifications = async ({
     GetNotificationUsersQueryVariables
   >(GetNotificationUsersDocument, {
     filter: {
-      or: recipients.map((address) => ({ id: { eq: address } })),
+      or: nonSelfRecipients.map((address) => ({ id: { eq: address } })),
     },
     limit: 9999,
   });


### PR DESCRIPTION
Quite basic, just don't send mention notifications if the recipient address is the same as the creator address.

This avoids notifications which are like: "You mentioned yourself in: Action 1" which just clog up your notification feed.

CDapp PR https://github.com/JoinColony/colonyCDapp/pull/3394 has testing steps :)