### PR TITLE
Fix: Only fire one notification on multisig approval

### DIFF
--- a/src/handlers/multiSig/approvalChanged/approvalChanged.ts
+++ b/src/handlers/multiSig/approvalChanged/approvalChanged.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers';
 import { ExtensionEventListener } from '~eventListeners';
 import { MultiSigVote, NotificationType } from '~graphql';
 import { getChainId } from '~provider';
@@ -66,7 +67,45 @@ export const handleMultiSigApprovalChanged: EventHandler = async (
       multiSigFromDB?.action?.type,
     );
 
-    if (notificationCategory && !motion.overallApprovalTimestamp.isZero()) {
+    let hasFullApproval = true;
+    let roleIndex = 0;
+
+    // Map over each permission.
+    while (
+      BigNumber.from(motion.requiredPermissions).gte(
+        BigNumber.from(1).shl(roleIndex),
+      )
+    ) {
+      // If the permission is required by this multi sig motion...
+      // (this logic is taken from the network, it's very cool I know)
+      if (
+        BigNumber.from(motion.requiredPermissions)
+          .and(BigNumber.from(1).shl(roleIndex))
+          .gt(BigNumber.from(0))
+      ) {
+        // Get the threshold for this role from the multi sig motion.
+        const thresholdForRole = await multiSigClient.getMotionVoteThreshold(
+          motionId,
+          role,
+        );
+
+        // Get the number of signatures for this role that have voted approve.
+        const approvalsForRole =
+          multiSigFromDB?.signatures?.items.filter(
+            (signature) =>
+              signature?.role === roleIndex &&
+              signature.vote === MultiSigVote.Approve,
+          ) ?? [];
+
+        // If the number of approval signatures for this role is less than the threshold, then the multi sig motion has not reached full approval.
+        if (thresholdForRole.gt(BigNumber.from(approvalsForRole.length))) {
+          hasFullApproval = false;
+        }
+      }
+      roleIndex += 1;
+    }
+
+    if (notificationCategory && hasFullApproval) {
       sendMultisigActionNotifications({
         colonyAddress,
         creator: userAddress,


### PR DESCRIPTION
When a multisig is fully approved, we should ensure that only one notification is fired about this approval. Previously one notification was being sent for each role the user voted with, which in the case of a simple payment for example is three, so you would end up with three notifications all at the same time saying that the multisig motion was approved.

CDapp PR here https://github.com/JoinColony/colonyCDapp/pull/3396 has the testing steps.