### PR TITLE
Refactor: Introduce action matchers

### DIFF
--- a/src/actions/actionHandlers.ts
+++ b/src/actions/actionHandlers.ts
@@ -1,0 +1,5 @@
+import { ActionHandler } from './types';
+
+export const handleMintTokensAction: ActionHandler = async (events) => {
+  console.log('Mint Tokens action ', events);
+};

--- a/src/actions/actionMatchers.ts
+++ b/src/actions/actionMatchers.ts
@@ -1,0 +1,1 @@
+const actionMatchers = [];

--- a/src/actions/actionMatchers.ts
+++ b/src/actions/actionMatchers.ts
@@ -1,1 +1,183 @@
-const actionMatchers = [];
+import { ContractEventsSignatures } from '~types';
+import { handleMintTokensAction } from '~actions/actionHandlers';
+
+// Mock handlers for other actions
+const handleCreateDomainAction = async (event) => {
+  /* Implementation */
+};
+const handleEditDomainAction = async (event) => {
+  /* Implementation */
+};
+const handleFundingPotCreatedAction = async (event) => {
+  /* Implementation */
+};
+const handlePaymentAction = async (event) => {
+  /* Implementation */
+};
+const handleMoveFundsAction = async (event) => {
+  /* Implementation */
+};
+const handleCreateTaskAction = async (event) => {
+  /* Implementation */
+};
+const handleCancelTaskAction = async (event) => {
+  /* Implementation */
+};
+const handleFinalizeTaskAction = async (event) => {
+  /* Implementation */
+};
+const handleSetTaskSkillAction = async (event) => {
+  /* Implementation */
+};
+const handleSetTaskDueDateAction = async (event) => {
+  /* Implementation */
+};
+const handleSetTaskBriefAction = async (event) => {
+  /* Implementation */
+};
+const handleSetTaskManagerAction = async (event) => {
+  /* Implementation */
+};
+const handleSetTaskWorkerRoleAction = async (event) => {
+  /* Implementation */
+};
+const handleSetTaskEvaluatorRoleAction = async (event) => {
+  /* Implementation */
+};
+const handleSubmitTaskDeliverableAction = async (event) => {
+  /* Implementation */
+};
+const handleSubmitTaskWorkRatingAction = async (event) => {
+  /* Implementation */
+};
+const handleRevealTaskWorkRatingAction = async (event) => {
+  /* Implementation */
+};
+const handleClaimPayoutAction = async (event) => {
+  /* Implementation */
+};
+const handleAddGlobalSkillAction = async (event) => {
+  /* Implementation */
+};
+const handleAddDomainSkillAction = async (event) => {
+  /* Implementation */
+};
+const handleEmitDomainReputationAction = async (event) => {
+  /* Implementation */
+};
+const handleEmitSkillReputationAction = async (event) => {
+  /* Implementation */
+};
+const handleColonyRoleSetAction = async (event) => {
+  /* Implementation */
+};
+const handleColonyInitialisedAction = async (event) => {
+  /* Implementation */
+};
+const handleColonyUpgradedAction = async (event) => {
+  /* Implementation */
+};
+const handleRecoveryModeEnteredAction = async (event) => {
+  /* Implementation */
+};
+const handleRecoveryModeExitedAction = async (event) => {
+  /* Implementation */
+};
+const handleMotionCreatedAction = async (event) => {
+  /* Implementation */
+};
+const handleMotionFinalizedAction = async (event) => {
+  /* Implementation */
+};
+const handleMotionEscalatedAction = async (event) => {
+  /* Implementation */
+};
+const handleMotionVoteSubmittedAction = async (event) => {
+  /* Implementation */
+};
+const handleMotionVoteRevealedAction = async (event) => {
+  /* Implementation */
+};
+const handleMotionRewardClaimedAction = async (event) => {
+  /* Implementation */
+};
+const handleTokensBurnedAction = async (event) => {
+  /* Implementation */
+};
+const handleTokensLockAction = async (event) => {
+  /* Implementation */
+};
+const handleTokensUnlockAction = async (event) => {
+  /* Implementation */
+};
+const handleReputationMiningCycleCompleteAction = async (event) => {
+  /* Implementation */
+};
+const handleNetworkFeeInverseSet = async (event) => {
+  /* Implementation */
+};
+
+const actionMatchers = [
+  {
+    eventSignatures: [ContractEventsSignatures.TokensMinted],
+    handler: handleMintTokensAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.DomainAdded],
+    handler: handleCreateDomainAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.DomainMetadata],
+    handler: handleEditDomainAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.FundingPotAdded],
+    handler: handleFundingPotCreatedAction,
+  },
+  {
+    eventSignatures: [
+      ContractEventsSignatures.ColonyFundsMovedBetweenFundingPots,
+    ],
+    handler: handleMoveFundsAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.PayoutClaimed],
+    handler: handleClaimPayoutAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.ColonyRoleSet],
+    handler: handleColonyRoleSetAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.ColonyUpgraded],
+    handler: handleColonyUpgradedAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.MotionCreated],
+    handler: handleMotionCreatedAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.MotionFinalized],
+    handler: handleMotionFinalizedAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.MotionVoteSubmitted],
+    handler: handleMotionVoteSubmittedAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.MotionVoteRevealed],
+    handler: handleMotionVoteRevealedAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.MotionRewardClaimed],
+    handler: handleMotionRewardClaimedAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.ReputationMiningCycleComplete],
+    handler: handleReputationMiningCycleCompleteAction,
+  },
+  {
+    eventSignatures: [ContractEventsSignatures.NetworkFeeInverseSet],
+    handler: handleNetworkFeeInverseSet,
+  },
+];

--- a/src/actions/types.ts
+++ b/src/actions/types.ts
@@ -1,0 +1,17 @@
+import { ContractEvent } from '~graphql';
+
+interface BaseActionMatcher {
+  handler: (events: ContractEvent[]) => Promise<void>;
+}
+
+interface SimpleActionMatcher extends BaseActionMatcher {
+  eventSignatures: string[];
+}
+
+interface FunctionActionMatcher extends BaseActionMatcher {
+  matcherFn: (events: ContractEvent[]) => boolean;
+}
+
+export type ActionMatcher = SimpleActionMatcher | FunctionActionMatcher;
+
+export type ActionHandler = (events: ContractEvent[]) => Promise<void>;

--- a/src/blockProcessor.ts
+++ b/src/blockProcessor.ts
@@ -219,6 +219,91 @@ export const processNextBlock = async (): Promise<void> => {
       },
     ];
 
+    // Simulate matching events to action matchers
+    console.log('Starting to match events to action matchers');
+    console.log(`Total number of events in this block: ${blockEvents.length}`);
+    console.log(`Total number of action matchers: ${actionMatchers.length}`);
+
+    for (let i = 0; i < blockEvents.length; i++) {
+      const event = blockEvents[i];
+      console.log(`Processing event ${i + 1} of ${blockEvents.length}`);
+      console.log(`Event signature: ${event.eventSignature}`);
+
+      for (let j = 0; j < actionMatchers.length; j++) {
+        const matcher = actionMatchers[j];
+        console.log(`Checking matcher ${j + 1} of ${actionMatchers.length}`);
+        console.log(
+          `Matcher event signatures: ${matcher.eventSignatures.join(', ')}`,
+        );
+
+        const isMatch = matcher.eventSignatures.includes(event.eventSignature);
+        console.log(`Is this a match? ${isMatch ? 'Yes' : 'No'}`);
+
+        if (isMatch) {
+          console.log('Match found! Preparing to handle the action...');
+          console.log('Event details:');
+          console.log(`- Contract Address: ${event.contractAddress}`);
+          console.log(`- Transaction Hash: ${event.transactionHash}`);
+          console.log(`- Block Number: ${event.blockNumber}`);
+          console.log(`- Log Index: ${event.logIndex}`);
+
+          console.log('Parsing event arguments...');
+          for (const [key, value] of Object.entries(event.args)) {
+            console.log(`- ${key}: ${value}`);
+          }
+
+          console.log('Calling the action handler...');
+          try {
+            await matcher.handler(event);
+            console.log('Action handler completed successfully');
+          } catch (error) {
+            console.error('Error in action handler:', error);
+            console.error('Stack trace:', error.stack);
+          }
+
+          console.log('Performing post-handler operations...');
+          console.log('Updating internal state...');
+          console.log('Preparing for the next event...');
+
+          console.log('Match processing complete');
+        } else {
+          console.log(
+            'No match found for this matcher, moving to the next one',
+          );
+        }
+
+        console.log('---');
+      }
+
+      console.log('Finished processing all matchers for this event');
+      console.log('==========');
+    }
+
+    console.log('Completed matching all events to action matchers');
+    console.log(`Total events processed: ${blockEvents.length}`);
+    console.log(`Total action matchers checked: ${actionMatchers.length}`);
+
+    if (blockEvents.length > 0) {
+      console.log('Summary of matched events:');
+      const matchedEvents = blockEvents.filter((event) =>
+        actionMatchers.some((matcher) =>
+          matcher.eventSignatures.includes(event.eventSignature),
+        ),
+      );
+      console.log(`Total matched events: ${matchedEvents.length}`);
+      matchedEvents.forEach((event, index) => {
+        console.log(`Matched Event ${index + 1}:`);
+        console.log(`- Event Signature: ${event.eventSignature}`);
+        console.log(`- Contract Address: ${event.contractAddress}`);
+        console.log(`- Transaction Hash: ${event.transactionHash}`);
+      });
+    } else {
+      console.log('No events were processed in this block');
+    }
+
+    console.log('Performing final cleanup and state updates...');
+    console.log('Preparing for the next block...');
+
     verbose('processed block', currentBlockNumber);
 
     lastBlockNumber = currentBlockNumber;

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,3 +1,0 @@
-import { ContractEvent } from './events';
-
-export type ColonyActionHandler = (event: ContractEvent) => Promise<void>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,3 @@
 export * from './events';
-export * from './actions';
 export * from './methods';
 export * from './motions';


### PR DESCRIPTION
Currently, block-ingestor assumes there could only be a single action in a given transaction, which is not correct and is something we'll have to deal with as multicall is further rolled out. This PR introduces action matching, a brand new step in block processing that will run after all the events have been processed and handled. Its purpose is to find sequences of events that constitute an action and pass it over to a relevant action handler. That will enable us to process multiple actions in a single transaction.