### PR TITLE
fix: always use roles passed to contract for motions

### DIFF
--- a/src/handlers/motions/motionCreated/handlers/setUserRoles.ts
+++ b/src/handlers/motions/motionCreated/handlers/setUserRoles.ts
@@ -2,11 +2,7 @@ import { TransactionDescription } from 'ethers/lib/utils';
 import { constants } from 'ethers';
 
 import { ContractEvent, motionNameMapping } from '~types';
-import {
-  getColonyRolesDatabaseId,
-  getDomainDatabaseId,
-  getRolesMapFromHexString,
-} from '~utils';
+import { getDomainDatabaseId, getRolesMapFromHexString } from '~utils';
 
 import { createMotionInDB } from '../helpers';
 
@@ -20,16 +16,7 @@ export const handleSetUserRolesMotion = async (
 
   const { name, args: actionArgs } = parsedAction;
   const [userAddress, domainId, zeroPadHexString] = actionArgs.slice(-3);
-  const colonyRolesDatabaseId = getColonyRolesDatabaseId(
-    colonyAddress,
-    domainId,
-    userAddress,
-    isMultiSig,
-  );
-  const roles = await getRolesMapFromHexString(
-    zeroPadHexString,
-    colonyRolesDatabaseId,
-  );
+  const roles = getRolesMapFromHexString(zeroPadHexString);
 
   await createMotionInDB(colonyAddress, event, {
     type: motionNameMapping[name],

--- a/src/handlers/multiSig/multiSigCreated/handlers/setUserRoles.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/setUserRoles.ts
@@ -4,6 +4,7 @@ import { ContractEvent, multiSigNameMapping } from '~types';
 import { getDomainDatabaseId, getRolesMapFromHexString } from '~utils';
 import { createMultiSigInDB } from '../helpers';
 import { sendMentionNotifications } from '~utils/notifications';
+import { constants } from 'ethers';
 
 export const handleSetUserRolesMultiSig = async (
   colonyAddress: string,
@@ -16,7 +17,7 @@ export const handleSetUserRolesMultiSig = async (
   }
   // When setting 'Own' authority, the action target will be the colonyAddress
   // When setting 'Multisig' authority, the action target will be the multisig extension address
-  const isMultiSig = actionTarget !== colonyAddress;
+  const isMultiSig = actionTarget !== constants.AddressZero;
 
   const { name, args: actionArgs } = parsedAction;
   const [userAddress, domainId, zeroPadHexString] = actionArgs.slice(-3);

--- a/src/handlers/multiSig/multiSigCreated/handlers/setUserRoles.ts
+++ b/src/handlers/multiSig/multiSigCreated/handlers/setUserRoles.ts
@@ -1,11 +1,7 @@
 import { TransactionDescription } from 'ethers/lib/utils';
 
 import { ContractEvent, multiSigNameMapping } from '~types';
-import {
-  getColonyRolesDatabaseId,
-  getDomainDatabaseId,
-  getRolesMapFromHexString,
-} from '~utils';
+import { getDomainDatabaseId, getRolesMapFromHexString } from '~utils';
 import { createMultiSigInDB } from '../helpers';
 import { sendMentionNotifications } from '~utils/notifications';
 
@@ -25,17 +21,7 @@ export const handleSetUserRolesMultiSig = async (
   const { name, args: actionArgs } = parsedAction;
   const [userAddress, domainId, zeroPadHexString] = actionArgs.slice(-3);
 
-  const colonyRolesDatabaseId = getColonyRolesDatabaseId(
-    colonyAddress,
-    domainId,
-    userAddress,
-    isMultiSig,
-  );
-
-  const roles = await getRolesMapFromHexString(
-    zeroPadHexString,
-    colonyRolesDatabaseId,
-  );
+  const roles = getRolesMapFromHexString(zeroPadHexString);
 
   await createMultiSigInDB(colonyAddress, event, {
     type: multiSigNameMapping[name],


### PR DESCRIPTION
Instead of getting the "delta" state and applying just the difference in roles in our database, we should just use whatever the FE passed to the contracts and apply it.
[CDApp PR](https://github.com/JoinColony/colonyCDapp/pull/3490)