### PR TITLE
Fix: Edit expenditure updating payouts when token changes

### DIFF
--- a/src/handlers/expenditures/helpers/createEditExpenditureAction.ts
+++ b/src/handlers/expenditures/helpers/createEditExpenditureAction.ts
@@ -173,8 +173,7 @@ export const createEditExpenditureAction = async (
 
       const convertedSlot = toNumber(slot);
       const existingPayouts =
-        expenditure.slots.find((slot) => slot.id === convertedSlot)?.payouts ??
-        [];
+        updatedSlots.find((slot) => slot.id === convertedSlot)?.payouts ?? [];
 
       const [amountLessFee, feeAmount] = await splitAmountAndFee(amountWithFee);
 


### PR DESCRIPTION
A subtle change without which setting new token for a payout while also editing an existing one did not work.

Consider the following scenario:

The UI wants to change a payout token from Token A to Token B. Since payouts can have multiple tokens, this process requires two steps: setting the new amount for Token B and setting Token A's amount to 0.

block-ingestor picks up the first `ExpenditurePayoutSet` for Token B and adds the updated payout to existing slot. However, when processing the second event, instead of applying the update to the recently modified slot, it incorrectly applies it to the original, unmodified slot. This results in the loss of Token B's payout information.
