### PR TITLE
Fix Reputation Mining Cycle Handler Timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
-        "@colony/colony-js": "7.2.0",
+        "@colony/colony-js": "^8.0.0-next.0",
         "@colony/events": "3.0.0",
         "@magicbell/core": "^5.0.16",
         "aws-amplify": "^4.3.43",
@@ -7398,14 +7398,45 @@
       }
     },
     "node_modules/@colony/colony-js": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-7.2.0.tgz",
-      "integrity": "sha512-vzXlYSoepHRnYIT2n8Ck9IV87vNPFRtUx2FAP834rVdCu4JwPPmNwKleH/7KBS9As92aaRYhlbzVDI9WQ+fgag==",
+      "version": "8.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/colony-js/-/colony-js-8.0.0-next.0.tgz",
+      "integrity": "sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@colony/core": "^2.3.0",
-        "@colony/events": "^3.0.0",
-        "@colony/tokens": "^0.3.0"
+        "@colony/core": "^3.0.0-next.0",
+        "@colony/events": "^4.0.0-next.0",
+        "@colony/tokens": "^1.0.0-next.0"
+      },
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/core": {
+      "version": "3.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/core/-/core-3.0.0-next.0.tgz",
+      "integrity": "sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==",
+      "license": "GPL-3.0-only",
+      "engines": {
+        "node": "^16 || ^18 || ^20",
+        "pnpm": "^8"
+      },
+      "peerDependencies": {
+        "ethers": "^5.1.3"
+      }
+    },
+    "node_modules/@colony/colony-js/node_modules/@colony/events": {
+      "version": "4.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/events/-/events-4.0.0-next.0.tgz",
+      "integrity": "sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==",
+      "license": "GPL-3.0-only",
+      "dependencies": {
+        "@colony/core": "^3.0.0-next.0",
+        "fetch-retry": "^5.0.4",
+        "typia": "^3.8.3"
       },
       "engines": {
         "node": "^16 || ^18 || ^20",
@@ -7447,9 +7478,9 @@
       }
     },
     "node_modules/@colony/tokens": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-0.3.0.tgz",
-      "integrity": "sha512-7rftWSWCos4OYjt2JgdGN4gHccXvm7Un0Cv8op4mQHWTVvX/0Oek4k0VOaQQgHpu/3yoRjDrI7ciqFpafRnwCg==",
+      "version": "1.0.0-next.0",
+      "resolved": "https://registry.npmjs.org/@colony/tokens/-/tokens-1.0.0-next.0.tgz",
+      "integrity": "sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==",
       "license": "GPL-3.0-only",
       "engines": {
         "node": "^16 || ^18 || ^20",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/JoinColony/tx-ingestor",
   "dependencies": {
-    "@colony/colony-js": "7.2.0",
+    "@colony/colony-js": "^8.0.0-next.0",
     "@colony/events": "3.0.0",
     "@magicbell/core": "^5.0.16",
     "aws-amplify": "^4.3.43",

--- a/src/handlers/reputationMiningCycle/reputationMiningCycleComplete.ts
+++ b/src/handlers/reputationMiningCycle/reputationMiningCycleComplete.ts
@@ -17,6 +17,21 @@ export default async (event: ContractEvent): Promise<void> => {
   // The event signature looks like: event ReputationMiningCycleComplete(bytes32 hash, uint256 nLeaves);
   // However, for current purposes (updating colony-wide contributor reputation), we don't care. We just need a timestamp.
 
+  // If we're running this in production, use the time of the actual
+  // mining cycle, which is the block time of when this event was emitted.
+  let lastCompletedAt = new Date(event.timestamp * 1000).toISOString();
+
+  // However, due to the time forwarding shennaningans we do when developing locally,
+  // This would break the UI badly, so we're forced to use the current time.
+  if (process.env.NODE_ENV === 'development') {
+    lastCompletedAt = new Date().toISOString();
+  }
+
+  // The current time cannot be used in production though, due to the fact that
+  // the ingestor might fall out of sync with the blockchain, and when it will attempt
+  // to catch up, and will come across this event, it will use an incorrect timestamp
+  // for it, basically the time it got to process it, meaning the UI will "lie" at that point
+
   const { data } =
     (await query<
       GetReputationMiningCycleMetadataQuery,
@@ -34,7 +49,7 @@ export default async (event: ContractEvent): Promise<void> => {
     >(UpdateReputationMiningCycleMetadataDocument, {
       input: {
         id: reputationMiningCycleMetadataId,
-        lastCompletedAt: new Date().toISOString(),
+        lastCompletedAt,
       },
     });
   } else {
@@ -44,7 +59,7 @@ export default async (event: ContractEvent): Promise<void> => {
     >(CreateReputationMiningCycleMetadataDocument, {
       input: {
         id: reputationMiningCycleMetadataId,
-        lastCompletedAt: new Date().toISOString(),
+        lastCompletedAt,
       },
     });
   }


### PR DESCRIPTION
This PR fixes the timestamp value for the `reputationMiningCycle` handler, since if the ingestor falls behind the chain, by the time it catches back up to this event it will have used the wrong timestamp for reputation, meaning both updates and UI reporting will be wrong.

This value is mostly used for UI display purposes, however, even so, if it gets out of date, users might get the wrong impression when looking up the reputation cycle's next update in the user hub