### PR TITLE
[Proxy colonies] Feat: Get the main-chain transaction hash from a proxy chain 

### DIFF
--- a/apps/main-chain/src/handlers/proxyColonies/proxyColonyRequested.ts
+++ b/apps/main-chain/src/handlers/proxyColonies/proxyColonyRequested.ts
@@ -1,7 +1,75 @@
-import { ContractEvent } from '@joincolony/blocks';
+import {
+  ContractEvent,
+  ContractEventsSignatures,
+  ProxyColonyEvents,
+} from '@joincolony/blocks';
+import { output } from '@joincolony/utils';
+import { constants, utils } from 'ethers';
+import blockManager from '~blockManager';
+import rpcProvider from '~provider';
+import { writeActionFromEvent } from '~utils/actions/writeAction';
+import { ColonyActionType } from '@joincolony/graphql';
 
 export const handleProxyColonyRequested = async (
   event: ContractEvent,
 ): Promise<void> => {
-  console.log('proxy colony requested event', event);
+  const { blockNumber, contractAddress: colonyAddress } = event;
+
+  const { destinationChainId } = event.args;
+
+  const logs = await rpcProvider.getProviderInstance().getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
+    topics: [
+      [
+        utils.id(ContractEventsSignatures.ProxyColonyRequested),
+        utils.id(ContractEventsSignatures.LogMessagePublished),
+      ],
+    ],
+  });
+
+  const events = await Promise.all(
+    logs.map((log) =>
+      blockManager.mapLogToContractEvent(log, ProxyColonyEvents),
+    ),
+  );
+
+  const wormholeEvent = events.find(
+    (event) =>
+      ContractEventsSignatures.LogMessagePublished === event?.signature,
+  );
+  const proxyRequestedEvent = events.find(
+    (event) =>
+      ContractEventsSignatures.ProxyColonyRequested === event?.signature,
+  );
+
+  if (!wormholeEvent || !proxyRequestedEvent) {
+    output(
+      `ProxyColonyRequested or LogMessagePublished are not present in the same block`,
+    );
+
+    return;
+  }
+
+  const { sender, sequence } = wormholeEvent.args;
+  const emitterAddress = sender.toString();
+  const emitterSequence = sequence.toString();
+
+  if (!emitterAddress || !sequence) {
+    output('Missing arguments on the LogMessagePublished events');
+    return;
+  }
+
+  await writeActionFromEvent(event, colonyAddress, {
+    type: ColonyActionType.AddProxyColony,
+    initiatorAddress: constants.AddressZero,
+    multiChainInfo: {
+      completed: false,
+      targetChainId: destinationChainId.toNumber(),
+      wormholeInfo: {
+        sequence: emitterSequence,
+        emitterAddress,
+      },
+    },
+  });
 };

--- a/apps/main-chain/src/multiChainBridgeClient.ts
+++ b/apps/main-chain/src/multiChainBridgeClient.ts
@@ -1,0 +1,7 @@
+import { WormholeClient } from "@joincolony/clients";
+
+const bridgeEndpoint = process.env.MULTI_CHAIN_BRIDGE_ENDPOINT ?? '';
+
+const client = new WormholeClient(bridgeEndpoint);
+
+export default client;

--- a/apps/proxy-chain/src/eventListeners/colony.ts
+++ b/apps/proxy-chain/src/eventListeners/colony.ts
@@ -3,10 +3,8 @@ import { addProxyColoniesEventListener } from './proxyColonies';
 import { handleProxyColonyDeployed } from '~handlers/proxyColonies';
 
 export const setupListenersForColonies = async (): Promise<void> => {
-
   addProxyColoniesEventListener(
     ContractEventsSignatures.ProxyColonyDeployed,
     handleProxyColonyDeployed,
   );
-
 };

--- a/apps/proxy-chain/src/handlers/proxyColonies/proxyColonyDeployed.ts
+++ b/apps/proxy-chain/src/handlers/proxyColonies/proxyColonyDeployed.ts
@@ -2,34 +2,157 @@ import {
   CreateProxyColonyDocument,
   CreateProxyColonyMutation,
   CreateProxyColonyMutationVariables,
+  GetActionInfoDocument,
+  GetActionInfoQuery,
+  GetActionInfoQueryVariables,
+  UpdateColonyActionDocument,
+  UpdateColonyActionMutation,
+  UpdateColonyActionMutationVariables,
 } from '@joincolony/graphql';
-import { ContractEvent } from '@joincolony/blocks';
+import {
+  ContractEvent,
+  ContractEventsSignatures,
+  ProxyColonyEvents,
+} from '@joincolony/blocks';
 import amplifyClient from '~amplifyClient';
 import rpcProvider from '~provider';
 import { output } from '@joincolony/utils';
+import { utils } from 'ethers';
+import blockManager from '~blockManager';
+import multiChainBridgeClient from '~multiChainBridgeClient';
 
 export const handleProxyColonyDeployed = async (
   event: ContractEvent,
 ): Promise<void> => {
-  console.log('proxy colony deployed event', event);
-  const { proxyColony: proxyColonyAddress } = event.args;
+  const {
+    blockNumber,
+    args: { proxyColony: proxyColonyAddress },
+  } = event;
 
   if (!proxyColonyAddress) {
     output('No proxyColony emitted!');
     return;
   }
 
-  const chainId = rpcProvider.getChainId();
+  const logs = await rpcProvider.getProviderInstance().getLogs({
+    fromBlock: blockNumber,
+    toBlock: blockNumber,
+    topics: [
+      [
+        utils.id(ContractEventsSignatures.ProxyColonyDeployed),
+        utils.id(ContractEventsSignatures.WormholeMessageReceived),
+      ],
+    ],
+  });
 
+  const events = await Promise.all(
+    logs.map((log) =>
+      blockManager.mapLogToContractEvent(log, ProxyColonyEvents),
+    ),
+  );
+
+  const wormholeEvent = events.find(
+    (event) =>
+      ContractEventsSignatures.WormholeMessageReceived === event?.signature,
+  );
+  const proxyDeployedEvent = events.find(
+    (event) =>
+      ContractEventsSignatures.ProxyColonyDeployed === event?.signature,
+  );
+
+  if (!wormholeEvent || !proxyDeployedEvent) {
+    output(
+      `ProxyColonyDeployed or WormholeMessageReceived are not present in the same block`,
+    );
+
+    return;
+  }
+
+  console.log(`RPC provider chain id`, rpcProvider.getChainId());
+  console.log(
+    `Mapped wormhole chain id`,
+    multiChainBridgeClient.getWormholeChainId(rpcProvider.getChainId()),
+  );
+
+  const { emitterChainId, emitterAddress, sequence } = wormholeEvent.args;
+  const chainId = rpcProvider.getChainId();
+  let sourceChainTxHash;
+  let isDeploymentCompleted = false;
+
+  try {
+    const multiChainBridgeOperationsData =
+      await multiChainBridgeClient.fetchOperationDetails({
+        emitterAddress,
+        emitterChainId,
+        sequence,
+      });
+
+    sourceChainTxHash =
+      multiChainBridgeOperationsData?.sourceChain?.transaction?.txHash;
+    const sourceChainOperationStatus =
+      multiChainBridgeOperationsData?.sourceChain?.status;
+    isDeploymentCompleted =
+      sourceChainOperationStatus ===
+      multiChainBridgeClient.REQ_STATUS.CONFIRMED;
+  } catch (error) {
+    output(
+      `Error while fetching multi-chain bridge operations details: ${
+        (error as Error).message
+      }.`,
+    );
+  }
+
+  if (!sourceChainTxHash) {
+    output(`Missing source chain txHash`);
+    return;
+  }
+
+  // if this event was fired we NEED to save it in the database, even if the action doesn't exist
   await amplifyClient.mutate<
     CreateProxyColonyMutation,
     CreateProxyColonyMutationVariables
-      >(CreateProxyColonyDocument, {
-        input: {
-          id: `${proxyColonyAddress}_${chainId}`,
-        colonyAddress: proxyColonyAddress,
-        chainId,
-        isActive: true,
+  >(CreateProxyColonyDocument, {
+    input: {
+      id: `${proxyColonyAddress}_${chainId}`,
+      colonyAddress: proxyColonyAddress,
+      chainId,
+      isActive: true,
+    },
+  });
+
+  const actionResponse = await amplifyClient.query<
+    GetActionInfoQuery,
+    GetActionInfoQueryVariables
+  >(GetActionInfoDocument, { transactionHash: sourceChainTxHash });
+  const actionData = actionResponse?.data?.getColonyAction;
+
+  if (!actionData) {
+    output(
+      `The txHash: ${sourceChainTxHash} is not an action on the main chain.`,
+    );
+    return;
+  }
+
+  if (!actionData.multiChainInfo) {
+    output(`The action: ${sourceChainTxHash} doesn't have multi chain data.`);
+    return;
+  }
+
+  await amplifyClient.mutate<
+    UpdateColonyActionMutation,
+    UpdateColonyActionMutationVariables
+  >(UpdateColonyActionDocument, {
+    input: {
+      id: sourceChainTxHash,
+      multiChainInfo: {
+        ...actionData.multiChainInfo,
+        completed: isDeploymentCompleted,
+        wormholeInfo: {
+          emitterAddress: emitterAddress.toString(),
+          emitterChainId,
+          sequence: sequence.toString(),
         },
-      });
+      },
+    },
+  });
 };

--- a/apps/proxy-chain/src/multiChainBridgeClient.ts
+++ b/apps/proxy-chain/src/multiChainBridgeClient.ts
@@ -1,0 +1,7 @@
+import { WormholeClient } from "@joincolony/clients";
+
+const bridgeEndpoint = process.env.MULTI_CHAIN_BRIDGE_ENDPOINT ?? '';
+
+const client = new WormholeClient(bridgeEndpoint);
+
+export default client;

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "homepage": "https://github.com/JoinColony/tx-ingestor",
   "dependencies": {
-    "@colony/colony-js": "^8.0.0-next.0",
-    "@colony/events": "^4.0.0-next.0",
+    "@colony/colony-js": "^8.0.0-next.1",
+    "@colony/events": "^4.0.0-next.1",
     "@magicbell/core": "^5.0.16",
     "aws-amplify": "^4.3.43",
     "cross-fetch": "^4.0.0",

--- a/packages/blocks/src/blocks/blockManager.ts
+++ b/packages/blocks/src/blocks/blockManager.ts
@@ -1,10 +1,7 @@
 import { Log } from '@ethersproject/abstract-provider';
 import { output, verbose } from '@joincolony/utils';
 import { EventManager, ContractEvent, EthersObserverEvents } from '../events';
-import {
-  Block,
-  BlockWithTransactions,
-} from './types';
+import { Block, BlockWithTransactions } from './types';
 import { RpcProvider } from '@joincolony/clients';
 import { utils } from 'ethers';
 import { StatsManager } from '../stats/statsManager';

--- a/packages/blocks/src/events/eventManager.ts
+++ b/packages/blocks/src/events/eventManager.ts
@@ -16,9 +16,12 @@ import {
 import { Extension, getExtensionHash } from '@colony/colony-js';
 
 // @TODO @chmanie is gonna make this better, for now let's just hardcode the proxy colony events
-const ProxyColonyEvents = new utils.Interface([
+export const ProxyColonyEvents = new utils.Interface([
   'event ProxyColonyRequested(uint256 destinationChainId, bytes32 salt)',
   'event ProxyColonyDeployed(address proxyColony)',
+  // @TODO decouple these into MultiChainBridgeEvents
+  'event WormholeMessageReceived(uint16 emitterChainId, bytes32 emitterAddress, uint64 sequence)',
+  'event LogMessagePublished(address indexed sender,uint64 sequence,uint32 nonce,bytes payload,uint8 consistencyLevel)',
 ]);
 
 export class EventManager {

--- a/packages/blocks/src/events/types.ts
+++ b/packages/blocks/src/events/types.ts
@@ -108,6 +108,8 @@ export enum ContractEventsSignatures {
   // Proxy colonies
   ProxyColonyRequested = 'ProxyColonyRequested(uint256,bytes32)',
   ProxyColonyDeployed = 'ProxyColonyDeployed(address)',
+  LogMessagePublished = 'LogMessagePublished(address,uint64,uint32,bytes,uint8)',
+  WormholeMessageReceived = 'WormholeMessageReceived(uint16,bytes32,uint64)',
 }
 
 /*

--- a/packages/clients/src/index.ts
+++ b/packages/clients/src/index.ts
@@ -1,4 +1,5 @@
 export { RpcProvider } from './rpcProvider';
 export * from './amplifyClient';
 export * from './networkClient';
+export * from './wormholeClient';
 // @TODO rename clients into providers

--- a/packages/clients/src/networkClient.ts
+++ b/packages/clients/src/networkClient.ts
@@ -1,23 +1,37 @@
-import { ColonyNetworkClient, Network, getColonyNetworkClient } from '@colony/colony-js';
+import {
+  ColonyNetworkClient,
+  Network,
+  NetworkClientOptions,
+  getColonyNetworkClient,
+} from '@colony/colony-js';
 
 import { RpcProvider } from './rpcProvider';
 
 export class NetworkClient {
-    private readonly rpcProvider: RpcProvider;
-    private readonly network: Network;
-    private readonly networkAddress?: string;
+  private readonly rpcProvider: RpcProvider;
+  private readonly network: Network;
+  private readonly networkAddress?: string;
 
-    constructor(rpcProvider: RpcProvider, network: Network, networkAddress?: string) {
-        this.rpcProvider = rpcProvider;
-        this.network = network;
-        this.networkAddress = networkAddress;
-    }
+  constructor(
+    rpcProvider: RpcProvider,
+    network: Network,
+    networkAddress?: string,
+  ) {
+    this.rpcProvider = rpcProvider;
+    this.network = network;
+    this.networkAddress = networkAddress;
+  }
 
-    // @TODO maybe add here an options object
-    public getInstance(): ColonyNetworkClient {
-        return getColonyNetworkClient(this.network, this.rpcProvider.getProviderInstance(), {
-            networkAddress: this.networkAddress,
-            disableVersionCheck: true,
-        });
-    }
+  public getInstance(
+    options: NetworkClientOptions = { disableVersionCheck: true },
+  ): ColonyNetworkClient {
+    return getColonyNetworkClient(
+      this.network,
+      this.rpcProvider.getProviderInstance(),
+      {
+        ...options,
+        networkAddress: this.networkAddress,
+      },
+    );
+  }
 }

--- a/packages/clients/src/types.ts
+++ b/packages/clients/src/types.ts
@@ -1,1 +1,20 @@
 export type ChainID = string;
+
+export type WormholeOperationsDetailsReturn =
+  | {
+      sourceChain: {
+        chainId: string;
+        transaction?: {
+          txHash: string;
+        };
+        status: string;
+      };
+      targetChain: {
+        chainId: string;
+        transaction?: {
+          txHash: string;
+        };
+        status: string;
+      };
+    }
+  | undefined;

--- a/packages/clients/src/wormholeClient.ts
+++ b/packages/clients/src/wormholeClient.ts
@@ -1,0 +1,98 @@
+import { BigNumber } from 'ethers';
+import { ChainID, WormholeOperationsDetailsReturn } from './types';
+import { NetworkId } from '@colony/colony-js';
+import { output } from '@joincolony/utils';
+
+export class WormholeClient {
+  private readonly bridgeEndpoint: string;
+
+  public REQ_STATUS = {
+    CONFIRMED: 'confirmed',
+  };
+
+  constructor(bridgeEndpoint: string) {
+    this.bridgeEndpoint = bridgeEndpoint;
+  }
+
+  /**
+   * Pads a hex string to a specific byte length.
+   * @param hexString - The hexadecimal string to pad.
+   * @param byteLength - The target byte length (default is 32).
+   * @returns The padded hexadecimal string.
+   */
+  private padHexToByteLength(hexString: string, byteLength = 32): string {
+    let cleanHex = hexString.startsWith('0x') ? hexString.slice(2) : hexString;
+
+    const targetHexLength = byteLength * 2;
+
+    if (cleanHex.length < targetHexLength) {
+      cleanHex = cleanHex.padStart(targetHexLength, '0');
+    }
+
+    return '0x' + cleanHex;
+  }
+
+  /**
+   * Resolves the Wormhole chain ID for a given blockchain chain ID.
+   *
+   * @param chainId - The blockchain chain ID to resolve (can be a number or string).
+   * @returns The corresponding Wormhole chain ID, or a default value for unmapped chains.
+   */
+  public getWormholeChainId(chainId: ChainID): number {
+    const chainIdAsNumber = Number.isInteger(chainId)
+      ? Number.parseInt(chainId)
+      : '';
+
+    switch (chainIdAsNumber) {
+      // On testnet
+      case NetworkId.Goerli:
+        return 2;
+      case NetworkId.Mainnet:
+        return 5;
+      case NetworkId.Gnosis:
+      case NetworkId.Xdai:
+      case NetworkId.XdaiQa:
+        return 25;
+      case NetworkId.Custom:
+      case NetworkId.ArbitrumSepolia:
+        return 10003;
+      case NetworkId.ArbitrumOne:
+        return 23;
+      default: {
+        output(
+          `Chain with id ${chainId} is not mapped to a Wormhole chain ID. Using custom`,
+        );
+        return 2;
+      }
+    }
+  }
+
+  /**
+   * Converts a BigNumber to a string for compatibility with the API.
+   * @param bigNumber - The BigNumber to convert.
+   * @returns The string representation of the BigNumber.
+   */
+  private bigNumberToString(bigNumber: BigNumber): string {
+    return bigNumber.toString();
+  }
+
+  /**
+   * Fetches operation details from the Wormhole bridge.
+   * @param args - The operation parameters including emitterChainId, emitterAddress, and sequence.
+   * @returns The response from the bridge API.
+   */
+  public async fetchOperationDetails(args: {
+    emitterChainId: number;
+    emitterAddress: string;
+    sequence: BigNumber;
+  }): Promise<WormholeOperationsDetailsReturn> {
+    const { emitterChainId, emitterAddress, sequence } = args;
+
+    const paddedEmitterAddress = this.padHexToByteLength(emitterAddress);
+    const sequenceString = this.bigNumberToString(sequence);
+
+    const url = `${this.bridgeEndpoint}/v1/operations/${emitterChainId}/${paddedEmitterAddress}/${sequenceString}`;
+    const request = await fetch(url);
+    return request.json();
+  }
+}

--- a/packages/graphql/src/fragments/actions.graphql
+++ b/packages/graphql/src/fragments/actions.graphql
@@ -1,3 +1,13 @@
+fragment MultiChainInfo on MultiChainInfo {
+  targetChainId
+  completed
+  wormholeInfo {
+    emitterChainId
+    emitterAddress
+    sequence
+  }
+}
+
 fragment ActionMetadataInfo on ColonyAction {
   id
   pendingDomainMetadata {
@@ -18,4 +28,7 @@ fragment ActionMetadataInfo on ColonyAction {
     recipientAddress
   }
   members
+  multiChainInfo {
+    ...MultiChainInfo
+  }
 }

--- a/packages/graphql/src/queries/action.graphql
+++ b/packages/graphql/src/queries/action.graphql
@@ -3,3 +3,9 @@ query GetColonyAction($transactionHash: ID!) {
     id
   }
 }
+
+query GetActionInfo($transactionHash: ID!) {
+  getColonyAction(id: $transactionHash) {
+    ...ActionMetadataInfo
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@colony/colony-js':
-        specifier: ^8.0.0-next.0
-        version: 8.0.0-next.0(ethers@5.7.2)(typescript@4.9.5)
+        specifier: ^8.0.0-next.1
+        version: 8.0.0-next.1(ethers@5.7.2)(typescript@4.9.5)
       '@colony/events':
-        specifier: ^4.0.0-next.0
-        version: 4.0.0-next.0(ethers@5.7.2)(typescript@4.9.5)
+        specifier: ^4.0.0-next.1
+        version: 4.0.0-next.1(ethers@5.7.2)(typescript@4.9.5)
       '@magicbell/core':
         specifier: ^5.0.16
         version: 5.1.0(react@18.3.1)
@@ -1515,26 +1515,26 @@ packages:
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
-  '@colony/colony-js@8.0.0-next.0':
-    resolution: {integrity: sha512-F46ElOrzhD/ktfYCQDf1ieNeBbIyWiDPd6cuHBjQ9yEU1iEo4pJfNt3J/57hZkwU+dY6wYqnU3NT7WCeu45u0A==}
+  '@colony/colony-js@8.0.0-next.1':
+    resolution: {integrity: sha512-up/4KT2vrpPxy1dBTIccQVCAKmoCwPvpFzQ2+NWsp69hY+WV+jHxhFpynFuOfhEOgMzqiESwicwDimQLHDXr5Q==}
     engines: {node: ^16 || ^18 || ^20, pnpm: ^8}
     peerDependencies:
       ethers: ^5.1.3
 
-  '@colony/core@3.0.0-next.0':
-    resolution: {integrity: sha512-IfdFoRwmMJOW3Hj6jzn8hOiwA9UxRFiYrEVJpnykm0n/I6c+IPDGZ4lg2sWdimvRa+bJit4gNP39rH+Mj0cHLg==}
+  '@colony/core@3.0.0-next.1':
+    resolution: {integrity: sha512-40F2Ok9FFKVHpAfUK8qJ/leOqUU7u79pKOjHZFDjL6FPIl5gHokLeDuZBlyHA8MOHxHaefxDRgXUZ1fbqyWh0Q==}
     engines: {node: ^16 || ^18 || ^20, pnpm: ^8}
     peerDependencies:
       ethers: ^5.1.3
 
-  '@colony/events@4.0.0-next.0':
-    resolution: {integrity: sha512-u89fmH6RlQWW8IeejfkZITsdptCm8zGx1a9qJ6F/p4ILY+EBnWdYkSdTZXITACU1r6sNSm4GkochTIjAy0R0ag==}
+  '@colony/events@4.0.0-next.1':
+    resolution: {integrity: sha512-Mcy8YMKzyFxH5QHBTPlPMmP3lm5S8ITNr2vv2UUy9iQNT7wGMqc2kqZtwtuN5KA0nW1HwvBkgfaFmiKjR5hlIg==}
     engines: {node: ^16 || ^18 || ^20, pnpm: ^8}
     peerDependencies:
       ethers: ^5.1.3
 
-  '@colony/tokens@1.0.0-next.0':
-    resolution: {integrity: sha512-j5YBk4nOXwDpYd1LnRyGOLVcRgfvkBgb85TI2aXKLwjRhB2V9f4Jdsy5ooqr7R9cQivYeCvfnEs5euPiHAhgqg==}
+  '@colony/tokens@1.0.0-next.1':
+    resolution: {integrity: sha512-vP4SD4lv4o3H160uE1PgWKt1d1zCd7H9W5lAu+XzKNJvd+OVVL5OSxu7XxVpo978tqQW1EgzWLNTbtP/Vl2oJQ==}
     engines: {node: ^16 || ^18 || ^20, pnpm: ^8}
     peerDependencies:
       ethers: ^5.1.3
@@ -8063,29 +8063,29 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@colony/colony-js@8.0.0-next.0(ethers@5.7.2)(typescript@4.9.5)':
+  '@colony/colony-js@8.0.0-next.1(ethers@5.7.2)(typescript@4.9.5)':
     dependencies:
-      '@colony/core': 3.0.0-next.0(ethers@5.7.2)
-      '@colony/events': 4.0.0-next.0(ethers@5.7.2)(typescript@4.9.5)
-      '@colony/tokens': 1.0.0-next.0(ethers@5.7.2)
+      '@colony/core': 3.0.0-next.1(ethers@5.7.2)
+      '@colony/events': 4.0.0-next.1(ethers@5.7.2)(typescript@4.9.5)
+      '@colony/tokens': 1.0.0-next.1(ethers@5.7.2)
       ethers: 5.7.2
     transitivePeerDependencies:
       - typescript
 
-  '@colony/core@3.0.0-next.0(ethers@5.7.2)':
+  '@colony/core@3.0.0-next.1(ethers@5.7.2)':
     dependencies:
       ethers: 5.7.2
 
-  '@colony/events@4.0.0-next.0(ethers@5.7.2)(typescript@4.9.5)':
+  '@colony/events@4.0.0-next.1(ethers@5.7.2)(typescript@4.9.5)':
     dependencies:
-      '@colony/core': 3.0.0-next.0(ethers@5.7.2)
+      '@colony/core': 3.0.0-next.1(ethers@5.7.2)
       ethers: 5.7.2
       fetch-retry: 5.0.6
       typia: 3.8.9(typescript@4.9.5)
     transitivePeerDependencies:
       - typescript
 
-  '@colony/tokens@1.0.0-next.0(ethers@5.7.2)':
+  '@colony/tokens@1.0.0-next.1(ethers@5.7.2)':
     dependencies:
       ethers: 5.7.2
 


### PR DESCRIPTION
This PR solves adding the new `ColonyActionType.AddProxyColony` action to DB on the main chain block ingestor, while also updating the action's `multiChainInfo` on the proxy chain block ingestor based on the data retrieved from the mocked `Wormhole` endpoint - this endpoint offers info about the deployment status on the requested proxy chain.

[CDapp PR](https://github.com/JoinColony/colonyCDapp/pull/3863)

### Changes

- Create the new action type `ColonyActionType.AddProxyColony` in the DB
- Added a new `WormholeClient` in the shared `clients` package
- Add multi-transaction processing for the proxy colony and wormhole events