### PR TITLE
Feat: Add `willPunishExpenditureStaker` field to colony motion

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -1106,6 +1106,11 @@ export type ColonyMotion = {
   /** A list of all of the votes cast within in the motion */
   voterRecord: Array<VoterRecord>;
   voterRewards?: Maybe<ModelVoterRewardsHistoryConnection>;
+  /**
+   * In case of motions cancelling a staked expenditure, boolean indicating
+   * whether the expenditure staker will be punished by losing their stake
+   */
+  willPunishExpenditureStaker?: Maybe<Scalars['Boolean']>;
 };
 
 /** Represents a Motion within a Colony */
@@ -1588,6 +1593,7 @@ export type CreateColonyMotionInput = {
   userMinStake: Scalars['String'];
   usersStakes: Array<UserMotionStakesInput>;
   voterRecord: Array<VoterRecordInput>;
+  willPunishExpenditureStaker?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type CreateColonyMultiSigInput = {
@@ -3242,6 +3248,7 @@ export type ModelColonyMotionConditionInput = {
   skillRep?: InputMaybe<ModelStringInput>;
   transactionHash?: InputMaybe<ModelIdInput>;
   userMinStake?: InputMaybe<ModelStringInput>;
+  willPunishExpenditureStaker?: InputMaybe<ModelBooleanInput>;
 };
 
 export type ModelColonyMotionConnection = {
@@ -3271,6 +3278,7 @@ export type ModelColonyMotionFilterInput = {
   skillRep?: InputMaybe<ModelStringInput>;
   transactionHash?: InputMaybe<ModelIdInput>;
   userMinStake?: InputMaybe<ModelStringInput>;
+  willPunishExpenditureStaker?: InputMaybe<ModelBooleanInput>;
 };
 
 export type ModelColonyMultiSigConditionInput = {
@@ -4412,6 +4420,7 @@ export type ModelSubscriptionColonyMotionFilterInput = {
   skillRep?: InputMaybe<ModelSubscriptionStringInput>;
   transactionHash?: InputMaybe<ModelSubscriptionIdInput>;
   userMinStake?: InputMaybe<ModelSubscriptionStringInput>;
+  willPunishExpenditureStaker?: InputMaybe<ModelSubscriptionBooleanInput>;
 };
 
 export type ModelSubscriptionColonyMultiSigFilterInput = {
@@ -9354,6 +9363,7 @@ export type UpdateColonyMotionInput = {
   userMinStake?: InputMaybe<Scalars['String']>;
   usersStakes?: InputMaybe<Array<UserMotionStakesInput>>;
   voterRecord?: InputMaybe<Array<VoterRecordInput>>;
+  willPunishExpenditureStaker?: InputMaybe<Scalars['Boolean']>;
 };
 
 export type UpdateColonyMultiSigInput = {

--- a/src/handlers/motions/motionCreated/handlers/expenditures/cancelStakedExpenditures.ts
+++ b/src/handlers/motions/motionCreated/handlers/expenditures/cancelStakedExpenditures.ts
@@ -13,7 +13,7 @@ export default async (
   { name, args: actionArgs }: TransactionDescription,
 ): Promise<void> => {
   const { args } = event;
-  const [, , , , expenditureId] = actionArgs;
+  const [, , , , expenditureId, willPunishExpenditureStaker] = actionArgs;
   const [, , domainId] = args;
 
   await createMotionInDB(colonyAddress, event, {
@@ -25,5 +25,6 @@ export default async (
       colonyAddress,
       toNumber(expenditureId),
     ),
+    willPunishExpenditureStaker,
   });
 };

--- a/src/handlers/motions/motionCreated/helpers.ts
+++ b/src/handlers/motions/motionCreated/helpers.ts
@@ -176,7 +176,10 @@ type MotionFields = Omit<
 > &
   Pick<
     CreateColonyMotionInput,
-    'expenditureSlotIds' | 'editedExpenditureSlots' | 'expenditureFunding'
+    | 'expenditureSlotIds'
+    | 'editedExpenditureSlots'
+    | 'expenditureFunding'
+    | 'willPunishExpenditureStaker'
   >;
 
 export const createMotionInDB = async (
@@ -195,6 +198,7 @@ export const createMotionInDB = async (
     expenditureSlotIds,
     editedExpenditureSlots,
     expenditureFunding,
+    willPunishExpenditureStaker,
     ...actionFields
   } = motionFields;
 
@@ -245,6 +249,7 @@ export const createMotionInDB = async (
       expenditureSlotIds,
       editedExpenditureSlots,
       expenditureFunding,
+      willPunishExpenditureStaker,
     }),
     createMotionMessage(initialMotionMessage),
     createColonyAction(actionData, timestamp),


### PR DESCRIPTION
Small PR to unblock [colonyCDapp#3322](https://github.com/JoinColony/colonyCDapp/pull/3322) which needs to be able to tell if a motion cancelling staked expenditure will also punish its creator or not.

## Testing 

- Check out `feat/cancel-exp-motion-field` in CDapp and start your dev env as usual.
- Install and enable Voting Reputation
- Create an expenditure and progress it past the Review stage
- From the three dot menu, select the cancel option
- Select Reputation as decision method and try both cases: penalising and not penalising the expenditure creator

Run the following query to check the value of `willPunishExpenditureStaker` field:
```gql

query Motions {
  listColonyActions(filter: {type: {eq: CANCEL_EXPENDITURE_MOTION}}) {
    items {
      id
      motionData {
        willPunishExpenditureStaker
      }
    }
  }
}

```