### PR TITLE
Feat: Enable and Disable Proxy Colonies via the Reputation Motion

### DIFF
--- a/apps/main-chain/src/handlers/metadataDelta/metadataDelta.ts
+++ b/apps/main-chain/src/handlers/metadataDelta/metadataDelta.ts
@@ -39,10 +39,12 @@ export default async (event: ContractEvent): Promise<void> => {
 
   if (isDisableProxyColonyOperation(operation)) {
     await handleDisableProxyColony(event, operation);
+    return;
   }
 
   if (isEnableProxyColonyOperation(operation)) {
     await handleEnableProxyColony(event, operation);
+    return;
   }
 
   verbose('Unknown operation type: ', operation);

--- a/apps/main-chain/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
+++ b/apps/main-chain/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
@@ -3,6 +3,8 @@ import { ColonyActionType } from '@joincolony/graphql';
 import { ContractEvent } from '@joincolony/blocks';
 import {
   isAddVerifiedMembersOperation,
+  isDisableProxyColonyOperation,
+  isEnableProxyColonyOperation,
   isManageTokensOperation,
   isRemoveVerifiedMembersOperation,
   parseMetadataDeltaOperation,
@@ -49,6 +51,27 @@ export const handleMetadataDeltaMotion = async (
         colonyAddress,
         event,
         operation,
+      });
+    }
+
+    if (
+      isDisableProxyColonyOperation(operation) ||
+      isEnableProxyColonyOperation(operation)
+    ) {
+      const targetChainId = JSON.parse(desc.args[0]).payload[0];
+
+      if (!targetChainId) {
+        return;
+      }
+
+      await createMotionInDB(colonyAddress, event, {
+        type: isDisableProxyColonyOperation(operation)
+          ? ColonyActionType.RemoveProxyColonyMotion
+          : ColonyActionType.AddProxyColonyMotion,
+        multiChainInfo: {
+          completed: false,
+          targetChainId: Number(targetChainId),
+        },
       });
     }
   } catch (error) {

--- a/apps/main-chain/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
+++ b/apps/main-chain/src/handlers/motions/motionCreated/handlers/metadataDelta.ts
@@ -58,7 +58,7 @@ export const handleMetadataDeltaMotion = async (
       isDisableProxyColonyOperation(operation) ||
       isEnableProxyColonyOperation(operation)
     ) {
-      const targetChainId = JSON.parse(desc.args[0]).payload[0];
+      const targetChainId = operation.payload[0];
 
       if (!targetChainId) {
         return;

--- a/apps/main-chain/src/handlers/motions/motionCreated/motionCreated.ts
+++ b/apps/main-chain/src/handlers/motions/motionCreated/motionCreated.ts
@@ -222,6 +222,7 @@ export const handleMotionCreated: EventHandler = async (
         );
         break;
       }
+
       case ColonyOperations.CreateProxyColony: {
         await handleCreateProxyColonyMotion(colonyAddress, event, parsedAction);
         break;

--- a/packages/graphql/src/generated.ts
+++ b/packages/graphql/src/generated.ts
@@ -698,6 +698,7 @@ export enum ColonyActionType {
   ReleaseStagedPaymentsMotion = 'RELEASE_STAGED_PAYMENTS_MOTION',
   /** An action related to disabling a proxy colony */
   RemoveProxyColony = 'REMOVE_PROXY_COLONY',
+  RemoveProxyColonyMotion = 'REMOVE_PROXY_COLONY_MOTION',
   /** An action related to removing verified members */
   RemoveVerifiedMembers = 'REMOVE_VERIFIED_MEMBERS',
   RemoveVerifiedMembersMotion = 'REMOVE_VERIFIED_MEMBERS_MOTION',


### PR DESCRIPTION
These changes should allow the enabling and disabling of Proxy Colonies via the Reputation decision method.

Please test this with [colonyCDapp PR #4063: Feat: Enable and Disable Proxy Colonies via the Reputation Motion ](https://github.com/JoinColony/colonyCDapp/pull/4063)