### PR TITLE
Feat: Enable and Disable Proxy Colonies via Multi-Sig

### DIFF
--- a/apps/main-chain/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
+++ b/apps/main-chain/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
@@ -57,7 +57,7 @@ export const handleMetadataDeltaMultiSig = async (
       isDisableProxyColonyOperation(operation) ||
       isEnableProxyColonyOperation(operation)
     ) {
-      const targetChainId = JSON.parse(desc.args[0]).payload[0];
+      const targetChainId = operation.payload[0];
 
       if (!targetChainId) {
         return;

--- a/apps/main-chain/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
+++ b/apps/main-chain/src/handlers/multiSig/multiSigCreated/handlers/metadataDelta.ts
@@ -3,6 +3,8 @@ import { ColonyActionType } from '@joincolony/graphql';
 import { ContractEvent } from '@joincolony/blocks';
 import {
   isAddVerifiedMembersOperation,
+  isDisableProxyColonyOperation,
+  isEnableProxyColonyOperation,
   isManageTokensOperation,
   isRemoveVerifiedMembersOperation,
   parseMetadataDeltaOperation,
@@ -49,6 +51,26 @@ export const handleMetadataDeltaMultiSig = async (
         colonyAddress,
         event,
         operation,
+      });
+    }
+    if (
+      isDisableProxyColonyOperation(operation) ||
+      isEnableProxyColonyOperation(operation)
+    ) {
+      const targetChainId = JSON.parse(desc.args[0]).payload[0];
+
+      if (!targetChainId) {
+        return;
+      }
+
+      await createMultiSigInDB(colonyAddress, event, {
+        type: isDisableProxyColonyOperation(operation)
+          ? ColonyActionType.RemoveProxyColonyMultisig
+          : ColonyActionType.AddProxyColonyMultisig,
+        multiChainInfo: {
+          completed: false,
+          targetChainId: Number(targetChainId),
+        },
       });
     }
   } catch (error) {

--- a/packages/graphql/src/generated.ts
+++ b/packages/graphql/src/generated.ts
@@ -699,6 +699,7 @@ export enum ColonyActionType {
   /** An action related to disabling a proxy colony */
   RemoveProxyColony = 'REMOVE_PROXY_COLONY',
   RemoveProxyColonyMotion = 'REMOVE_PROXY_COLONY_MOTION',
+  RemoveProxyColonyMultisig = 'REMOVE_PROXY_COLONY_MULTISIG',
   /** An action related to removing verified members */
   RemoveVerifiedMembers = 'REMOVE_VERIFIED_MEMBERS',
   RemoveVerifiedMembersMotion = 'REMOVE_VERIFIED_MEMBERS_MOTION',


### PR DESCRIPTION
These changes should allow the enabling and disabling of Proxy Colonies via the Multi-Sig decision method.

Please test this with [colonyCDapp PR #4079: Feat: Enable and Disable Proxy Colonies via Multi-Sig ](https://github.com/JoinColony/colonyCDapp/pull/4079)