### PR TITLE
[Proxy colonies M0] Align CHAIN_NETWORK_CONTRACT and CHAIN_CONTRACT_ADDRESS on block ingestor

### DIFF
--- a/apps/main-chain/src/eventListeners/network.ts
+++ b/apps/main-chain/src/eventListeners/network.ts
@@ -1,4 +1,8 @@
-import { EventListenerType , ContractEventsSignatures, EventHandler } from '@joincolony/blocks';
+import {
+  EventListenerType,
+  ContractEventsSignatures,
+  EventHandler,
+} from '@joincolony/blocks';
 import { utils } from 'ethers';
 
 import eventManager from '~eventManager';
@@ -11,6 +15,6 @@ export const addNetworkEventListener = (
     type: EventListenerType.Network,
     eventSignature,
     topics: [utils.id(eventSignature)],
-    address: process.env.CHAIN_CONTRACT_ADDRESS ?? '',
+    address: process.env.CHAIN_NETWORK_CONTRACT ?? '',
     handler,
   });

--- a/apps/main-chain/src/eventListeners/proxyColonies.ts
+++ b/apps/main-chain/src/eventListeners/proxyColonies.ts
@@ -1,6 +1,10 @@
 import { utils } from 'ethers';
 
-import { ContractEventsSignatures, EventHandler , EventListenerType } from '@joincolony/blocks';
+import {
+  ContractEventsSignatures,
+  EventHandler,
+  EventListenerType,
+} from '@joincolony/blocks';
 import eventManager from '~eventManager';
 
 export const addProxyColoniesEventListener = (
@@ -11,6 +15,6 @@ export const addProxyColoniesEventListener = (
     type: EventListenerType.ProxyColonies,
     eventSignature,
     topics: [utils.id(eventSignature)],
-    address: process.env.CHAIN_CONTRACT_ADDRESS ?? '',
+    address: process.env.CHAIN_NETWORK_CONTRACT ?? '',
     handler,
   });

--- a/apps/proxy-chain/src/eventListeners/network.ts
+++ b/apps/proxy-chain/src/eventListeners/network.ts
@@ -1,4 +1,8 @@
-import { EventListenerType , ContractEventsSignatures, EventHandler } from '@joincolony/blocks';
+import {
+  EventListenerType,
+  ContractEventsSignatures,
+  EventHandler,
+} from '@joincolony/blocks';
 import { utils } from 'ethers';
 
 import eventManager from '~eventManager';
@@ -11,6 +15,6 @@ export const addNetworkEventListener = (
     type: EventListenerType.Network,
     eventSignature,
     topics: [utils.id(eventSignature)],
-    address: process.env.CHAIN_CONTRACT_ADDRESS ?? '',
+    address: process.env.CHAIN_NETWORK_CONTRACT ?? '',
     handler,
   });

--- a/apps/proxy-chain/src/eventListeners/proxyColonies.ts
+++ b/apps/proxy-chain/src/eventListeners/proxyColonies.ts
@@ -1,6 +1,10 @@
 import { utils } from 'ethers';
 
-import { ContractEventsSignatures, EventHandler , EventListenerType } from '@joincolony/blocks';
+import {
+  ContractEventsSignatures,
+  EventHandler,
+  EventListenerType,
+} from '@joincolony/blocks';
 import eventManager from '~eventManager';
 
 export const addProxyColoniesEventListener = (
@@ -11,6 +15,6 @@ export const addProxyColoniesEventListener = (
     type: EventListenerType.ProxyColonies,
     eventSignature,
     topics: [utils.id(eventSignature)],
-    address: process.env.CHAIN_CONTRACT_ADDRESS ?? '',
+    address: process.env.CHAIN_NETWORK_CONTRACT ?? '',
     handler,
   });


### PR DESCRIPTION
Due to the fact both `CHAIN_CONTRACT_ADDRESS` and `CHAIN_NETWORK_CONTRACT` should point to the same value, given the `CHAIN_NETWORK_CONTRACT` is already setup in the dApp, I have removed the `CHAIN_CONTRACT_ADDRESS`.

The only impact is for the `addNetworkEventListener` and `addProxyColoniesEventListener` utilities that will now add the listeners for the given network contract address.

[CDapp PR](https://github.com/JoinColony/colonyCDapp/pull/4136)

