### PR TITLE
Add rate limited notifications queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "express": "^4.18.2",
         "fs-extra": "^10.1.0",
         "graphql": "^16.6.0",
-        "lodash": "^4.17.21"
+        "lodash": "^4.17.21",
+        "p-queue": "^6.6.2"
       },
       "devDependencies": {
         "@colony/wagmi-plugin": "^0.1.1",
@@ -18348,7 +18349,6 @@
     "node_modules/p-finally": {
       "version": "1.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -18391,6 +18391,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "express": "^4.18.2",
     "fs-extra": "^10.1.0",
     "graphql": "^16.6.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "p-queue": "^6.6.2"
   },
   "devDependencies": {
     "@colony/wagmi-plugin": "^0.1.1",


### PR DESCRIPTION
We recently saw an error where we had hit the API rate limit for Magicbell. This limit is set to 60 requests per minute. There is a decent chance we will hit this limit again - especially in the way that it happened today.

This was when a new version of an extension was released, and we looped over every colony to send a notification to their users who had the permissions to upgrade. We make one API call per colony (luckily we don't need to do it per user since we can pass an array of recipients), and if there are more than 60 colonies as we have on QA, then this will immediately hit our rate limit and the notifications will never be sent.

Even worse than this, it then blocks _any_ notifications from being sent to _anyone_ for potentially the next minute (or until the minute interval has ended) and these notifications are not currently being queued, they just will never fire.

This PR aims to remedy that, by making use of the [p-queue](https://github.com/sindresorhus/p-queue) package. I did some research before picking this package, and find that it is well maintained, well documented, and has a well sized user base. It also fits the needs perfectly for fixing this issue. The caveat is, I had to install it at a slightly earlier-than-latest version, since the latest is ESM only and wasn't compatible with how our block ingestor is set up.

Now, when we want to fire a notification, it enters a queue. The p-queue package handles this queueing and function firing for us, and it will only trigger functions in the queue if we are inside the rate that we have defined (matching Magicbell's 60 per minute).

Now we can feasibly trigger as many notifications at one go as we want, and we won't get rate limited, although it will take some time to fire them all. Better than them all failing after 60 though!

CDapp PR here: